### PR TITLE
Typography 컴포넌트 제작

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -43,5 +43,6 @@ module.exports = {
     'no-unused-vars': 'off',
     'no-console': 'off',
     'no-shadow': 'off',
+    '@typescript-eslint/no-shadow': 'error',
   },
 };

--- a/client/src/common/styles/theme.ts
+++ b/client/src/common/styles/theme.ts
@@ -1,4 +1,5 @@
 import { createMuiTheme } from '@material-ui/core/styles';
+import grey from '@material-ui/core/colors/grey';
 
 const theme = createMuiTheme({
   overrides: {
@@ -20,6 +21,42 @@ const theme = createMuiTheme({
         '&:hover': {
           backgroundColor: '#f5f5f5',
         },
+      },
+    },
+  },
+  palette: {
+    primary: {
+      main: '#ffb84d',
+    },
+    secondary: {
+      main: '#f3f3f3',
+    },
+    grey: {
+      50: grey[50],
+      100: grey[100],
+      200: grey[200],
+      300: grey[300],
+      400: grey[400],
+      500: grey[500],
+      600: grey[600],
+      700: grey[700],
+      800: grey[800],
+      900: grey[900],
+    },
+  },
+  props: {
+    MuiTypography: {
+      variantMapping: {
+        h1: 'h2',
+        h2: 'h2',
+        h3: 'h2',
+        h4: 'h2',
+        h5: 'h2',
+        h6: 'h2',
+        subtitle1: 'h2',
+        subtitle2: 'h2',
+        body1: 'span',
+        body2: 'span',
       },
     },
   },

--- a/client/src/components/UI/atoms/Typography/Typography.stories.tsx
+++ b/client/src/components/UI/atoms/Typography/Typography.stories.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import { Typography, TypographyProps, TypographyType } from '@/components/UI/atoms';
+
+export default {
+  title: 'atom/Typography',
+  component: Typography,
+  decorators: [withKnobs],
+} as Meta;
+
+const Template: Story<TypographyProps> = (args) => <Typography {...args} />;
+
+export const XLTypography = Template.bind({});
+XLTypography.args = {
+  typoType: TypographyType.primary,
+  size: 'XL',
+  content: '한표',
+};
+
+export const LTypography = Template.bind({});
+LTypography.args = {
+  typoType: TypographyType.primary,
+  size: 'L',
+  content: '한표',
+};
+
+export const MTypography = Template.bind({});
+MTypography.args = {
+  typoType: TypographyType.primary,
+  size: 'M',
+  content: '한표',
+};
+
+export const STypography = Template.bind({});
+STypography.args = {
+  typoType: TypographyType.primary,
+  size: 'S',
+  content: '한표',
+};
+
+export const XSTypography = Template.bind({});
+XSTypography.args = {
+  typoType: TypographyType.primary,
+  size: 'XS',
+  content: '한표',
+};

--- a/client/src/components/UI/atoms/Typography/Typography.stories.tsx
+++ b/client/src/components/UI/atoms/Typography/Typography.stories.tsx
@@ -15,33 +15,33 @@ export const XLTypography = Template.bind({});
 XLTypography.args = {
   typoType: TypographyType.primary,
   size: 'XL',
-  content: '한표',
+  children: '한표',
 };
 
 export const LTypography = Template.bind({});
 LTypography.args = {
   typoType: TypographyType.primary,
   size: 'L',
-  content: '한표',
+  children: '한표',
 };
 
 export const MTypography = Template.bind({});
 MTypography.args = {
   typoType: TypographyType.primary,
   size: 'M',
-  content: '한표',
+  children: '한표',
 };
 
 export const STypography = Template.bind({});
 STypography.args = {
   typoType: TypographyType.primary,
   size: 'S',
-  content: '한표',
+  children: '한표',
 };
 
 export const XSTypography = Template.bind({});
 XSTypography.args = {
   typoType: TypographyType.primary,
   size: 'XS',
-  content: '한표',
+  children: '한표',
 };

--- a/client/src/components/UI/atoms/Typography/Typography.tsx
+++ b/client/src/components/UI/atoms/Typography/Typography.tsx
@@ -16,10 +16,6 @@ interface TypographyProps {
   onClick?: () => void;
 }
 
-interface StyleProps {
-  size?: string;
-}
-
 const useStyles = makeStyles((theme) => ({
   primary: {
     color: theme.palette.primary.main,

--- a/client/src/components/UI/atoms/Typography/Typography.tsx
+++ b/client/src/components/UI/atoms/Typography/Typography.tsx
@@ -9,7 +9,7 @@ enum TypographyType {
 }
 
 interface TypographyProps {
-  content: string;
+  children: string;
   size: string;
   typoType: TypographyType;
   css?: string;
@@ -25,7 +25,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const StyledTypography = ({ content, size, typoType, css, onClick }: TypographyProps): JSX.Element => {
+const StyledTypography = ({ children, size, typoType, css, onClick }: TypographyProps): JSX.Element => {
   const classes = useStyles({ size });
 
   const getClassName = () => {
@@ -51,7 +51,7 @@ const StyledTypography = ({ content, size, typoType, css, onClick }: TypographyP
 
   return (
     <StyleTypography className={getClassName()} onClick={onClick}>
-      {content}
+      {children}
     </StyleTypography>
   );
 };

--- a/client/src/components/UI/atoms/Typography/Typography.tsx
+++ b/client/src/components/UI/atoms/Typography/Typography.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import styled from 'styled-components';
+
+enum TypographyType {
+  primary = 'primary',
+  secondary = 'secondary',
+}
+
+interface TypographyProps {
+  content: string;
+  size: string;
+  typoType: TypographyType;
+  css?: string;
+  onClick?: () => void;
+}
+
+interface StyleProps {
+  size?: string;
+}
+
+const useStyles = makeStyles((theme) => ({
+  primary: {
+    color: theme.palette.primary.main,
+  },
+  secondary: {
+    color: theme.palette.secondary.main,
+  },
+}));
+
+const StyledTypography = ({ content, size, typoType, css, onClick }: TypographyProps): JSX.Element => {
+  const classes = useStyles({ size });
+
+  const getClassName = () => {
+    return { ...classes }[typoType];
+  };
+
+  const Sizes: any = {
+    XL: '3.5em',
+    L: '2.2em',
+    M: '1.5em',
+    S: '1em',
+    XS: '0.7em',
+  };
+
+  const getSize = () => {
+    return { ...Sizes }[size];
+  };
+
+  const StyleTypography = styled(Typography)`
+    ${css}
+    font-size: ${getSize()}
+  `;
+
+  return (
+    <StyleTypography className={getClassName()} onClick={onClick}>
+      {content}
+    </StyleTypography>
+  );
+};
+
+export { StyledTypography, TypographyType };
+export type { TypographyProps };

--- a/client/src/components/UI/atoms/index.ts
+++ b/client/src/components/UI/atoms/index.ts
@@ -2,3 +2,5 @@ export { Hello } from './Hello/Hello';
 export type { HelloProps } from './Hello/Hello';
 export { StyledButton as Button, ButtonType } from './Button/Button';
 export type { ButtonProps } from './Button/Button';
+export { StyledTypography as Typography, TypographyType } from './Typography/Typography';
+export type { TypographyProps } from './Typography/Typography';


### PR DESCRIPTION
## 📑 제목

Typography 컴포넌트 제작

## 💬 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] Material UI에서 제공하는 Typography를 사용해 제작
- [x] props를 통해 필요한 것들 전달 받게 제작

## 🚧 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- Style을 관리하는 것에 있어 StyledComponent와 Material UI의 makeStyles를 사용했습니다. 사실 두 개가 비슷한 컨셉이라 하나만 사용할까 했지만 나중에 코드를 수정할 때 유연함을 위해 두 가지 모두를 사용하기로 결정했습니다.
- Customizing을 하고 싶다면 props의 css를 활용하면 됩니다. Template literal을 props로 전달하면 해당 style이 덮어 씌워지니 참고하세요.
- typoType은 primary와 secondary를 전달할 수 있습니다. 현재는 문자의 색상에만 관여하지만 개발을 진행하면서 필요하다 싶은 속성을 지속적으로 추가합시다.
- size는 XL~XS까지 입니다. 글자의 크기를 어떻게 할까 하다가 우선 반응형을 고려하여 em단위로 적절하다고 생각하는 크기를 임의로 설정했습니다. 추후 논의를 통해 확장해나가면 좋을 듯 싶습니다.
- **Storybook 관련해서 아래와 같은 현상이 발생하는데 혹시 이유를 아시는지 여쭤보고 싶어요!** 새로고침을 하면 원하는대로 잘 나오는데 다른 걸 클릭하면 글자 크기가 변하지가 않네요 ㅠㅠ

![Storybook오류](https://user-images.githubusercontent.com/46101366/108527474-a97d4a00-7315-11eb-8e00-86d9afe936f2.gif)
