### PR TITLE
클라이언트 스토어 구조변경

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,18 +1,23 @@
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { ApolloProvider } from '@apollo/react-hooks';
-import { ThemeProvider } from '@material-ui/core/styles';
+import { ThemeProvider } from '@material-ui/core';
 import { theme } from '@/common/styles';
+import { StoreProvider, RootStore } from '@/stores';
 import { Router } from './router';
 import apollo from './apollo';
+
+const rootStore = new RootStore();
 
 const App = (): JSX.Element => {
   return (
     <ApolloProvider client={apollo}>
       <ThemeProvider theme={theme}>
-        <BrowserRouter>
-          <Router />
-        </BrowserRouter>
+        <StoreProvider value={rootStore}>
+          <BrowserRouter>
+            <Router />
+          </BrowserRouter>
+        </StoreProvider>
       </ThemeProvider>
     </ApolloProvider>
   );

--- a/client/src/stores/ModalStore.ts
+++ b/client/src/stores/ModalStore.ts
@@ -1,0 +1,49 @@
+import { makeVar, ReactiveVar } from '@apollo/client';
+import { RootStore } from '@/stores';
+
+enum ModalType {
+  TAB_ADD_MODAL = 'TAB_ADD_MODAL',
+  TAB_REMOVE_MODAL = 'TAB_REMOVE_MODAL',
+}
+
+interface ModalStoreState {
+  modalState: ReactiveVar<boolean>;
+  modalType: ReactiveVar<ModalType>;
+}
+
+class ModalStore {
+  rootStore: RootStore;
+
+  state: ModalStoreState;
+
+  constructor(rootStore: RootStore) {
+    this.rootStore = rootStore;
+    this.state = {
+      modalState: makeVar<boolean>(false),
+      modalType: makeVar<ModalType>(ModalType.TAB_ADD_MODAL),
+    };
+  }
+
+  changeModalState(newModalType: ModalType, newModalState: boolean): void {
+    this.setModalType(newModalType);
+    this.setModalState(newModalState);
+  }
+
+  setModalType(newModalType: ModalType): void {
+    const { modalType } = this.state;
+
+    if (modalType() === newModalType) return;
+
+    modalType(newModalType);
+  }
+
+  setModalState(newModalState: boolean): void {
+    const { modalState } = this.state;
+
+    if (modalState() === newModalState) return;
+
+    modalState(newModalState);
+  }
+}
+
+export default ModalStore;

--- a/client/src/stores/RootStore.ts
+++ b/client/src/stores/RootStore.ts
@@ -1,0 +1,14 @@
+import { ModalStore, TimeTableStore } from '@/stores';
+
+class RootStore {
+  modalStore: ModalStore;
+
+  timeTableStore: TimeTableStore;
+
+  constructor() {
+    this.modalStore = new ModalStore(this);
+    this.timeTableStore = new TimeTableStore(this);
+  }
+}
+
+export default RootStore;

--- a/client/src/stores/StoreContext.tsx
+++ b/client/src/stores/StoreContext.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { RootStore } from '@/stores';
+
+export const StoreContext = React.createContext(new RootStore());
+export const StoreProvider = StoreContext.Provider;
+export const useStores = (): RootStore => React.useContext(StoreContext);

--- a/client/src/stores/TimeTableStore.ts
+++ b/client/src/stores/TimeTableStore.ts
@@ -1,0 +1,69 @@
+import { makeVar, ReactiveVar } from '@apollo/client';
+import { RootStore } from '@/stores';
+
+interface TableInfo {
+  name: string;
+  index: number;
+}
+
+interface TimeTableStoreState {
+  selectedTabIdx: ReactiveVar<any>;
+  tables: ReactiveVar<TableInfo[]>;
+  tableIndex: ReactiveVar<number>;
+}
+
+class TimeTableStore {
+  rootStore: RootStore;
+
+  state: TimeTableStoreState;
+
+  constructor(rootStore: RootStore) {
+    this.rootStore = rootStore;
+    this.state = {
+      selectedTabIdx: makeVar<any>(0),
+      tables: makeVar<TableInfo[]>([]),
+      tableIndex: makeVar(0),
+    };
+  }
+
+  selectTab(newSelectedTabIdx: any): void {
+    const { selectedTabIdx } = this.state;
+
+    if (selectedTabIdx === newSelectedTabIdx) return;
+
+    selectedTabIdx(newSelectedTabIdx);
+  }
+
+  addTable(name: string): void {
+    const { modalStore } = this.rootStore;
+    const { tableIndex, tables } = this.state;
+    const nextIndex = tableIndex() + 1;
+    const newTable = {
+      name,
+      index: nextIndex,
+    };
+    const newTables = [...tables(), newTable];
+
+    tables(newTables);
+    tableIndex(nextIndex);
+
+    this.selectTab(tables().length);
+    modalStore.setModalState(false);
+  }
+
+  removeTable(input: any): void {
+    const { modalStore } = this.rootStore;
+    const { tables, selectedTabIdx } = this.state;
+
+    if (tables().length === 1) return;
+
+    const nextSelectedTab = selectedTabIdx() === 1 ? 0 : selectedTabIdx() - 1;
+    const newTables = tables().filter((elem, idx) => idx !== selectedTabIdx() - 1);
+
+    tables(newTables);
+    this.selectTab(nextSelectedTab);
+    modalStore.setModalState(false);
+  }
+}
+
+export default TimeTableStore;

--- a/client/src/stores/index.ts
+++ b/client/src/stores/index.ts
@@ -1,0 +1,4 @@
+export { default as RootStore } from './RootStore';
+export { default as ModalStore } from './ModalStore';
+export { default as TimeTableStore } from './TimeTableStore';
+export * from './StoreContext';

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.paths.json",
   "compilerOptions": {
-    "target": "es6",
+    "target": "ESNext",
     "lib": [
       "dom",
       "dom.iterable",
@@ -18,7 +18,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
-    "module": "esnext",
+    "module": "ESNext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
@@ -29,10 +29,12 @@
     "strictNullChecks": true
   },
   "include": [
-    "src",
-    "src/__test__"
+    "src/**/*.ts",
+    "src/__test__/**/*.ts",
+    "src/stores/StoreContext.tsx"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    ".vscode"
   ]
 }


### PR DESCRIPTION
## 📑 제목

#25  클라이언트 스토어 구조변경


## 💬 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 기존 스토어 구조에서 TimeTableStore, ModalStore로 상태관리 역할에 따라 클래스로 구조화
- [x] RootStore를 정의하여 각각의 스토어를 전역 스토어로 접근가능하도록 구조화
- [x] Context API를 활용하여 전역 스토어를 접근가능하도록 구현
        -  StoreProvider를 정의하여 최상위 컴포넌트에 Wrapping
        -  useStore 훅을 정의하여 하위 컴포넌트에서 바로 전역 스토어에 접근가능하도록 구현
- [x] tsconfig 설정 변경
        - module, target 설정을 es 최신버전으로 설정
        - include 경로를 구체적으로 지정, exclude 경로에 .vscode 추가


## 🚧 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- ModalStore는 Modal을 dialog로 다시 구현하기로 하여 불필요한 코드들을 포함시키지 않았습니다.
- TimeTableStore는 기존의 코드를 그대로 가져와서 구성했는데, 문제가 있으면 얼마든지 수정해주세요!!! :)