### PR TITLE
Modal 컴포넌트 수정 작업

### DIFF
--- a/client/.storybook/preview.js
+++ b/client/.storybook/preview.js
@@ -1,15 +1,20 @@
 import React from 'react';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { theme } from '@/common/styles';
+import { StoreProvider, RootStore } from '@/stores';
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
 }
 
+const rootStore = new RootStore();
+
 export const decorators = [
   (Story) => (
     <ThemeProvider theme={theme}>
-      <Story />
+      <StoreProvider value={rootStore}>
+        <Story />
+      </StoreProvider>
     </ThemeProvider>
   ),
 ];

--- a/client/src/components/HOC/index.ts
+++ b/client/src/components/HOC/index.ts
@@ -1,0 +1,1 @@
+export { default as withStoryBox } from './withStoryBox/withStoryBox';

--- a/client/src/components/HOC/withStoryBox/withStoryBox.tsx
+++ b/client/src/components/HOC/withStoryBox/withStoryBox.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Box } from '@material-ui/core';
+
+const withStoryBox = (args: <T>() => T, width = 'auto', height = 'auto') => (StoryComponent: React.FC): React.FC => {
+  return (): JSX.Element => {
+    return (
+      <Box width={width} height={height}>
+        <StoryComponent {...args} />
+      </Box>
+    );
+  };
+};
+
+export default withStoryBox;

--- a/client/src/components/UI/molecules/ModalPopupArea/ModalPopupArea.stories.tsx
+++ b/client/src/components/UI/molecules/ModalPopupArea/ModalPopupArea.stories.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import { action } from '@storybook/addon-actions';
+import { Box } from '@material-ui/core';
+import { ModalPopupArea, ModalPopupAreaProps } from './ModalPopupArea';
+
+export default {
+  title: 'molecules/ModalPopupArea',
+  component: ModalPopupArea,
+  decorators: [withKnobs],
+} as Meta;
+
+const TestModalContent = (): JSX.Element => {
+  return <Box width={300} height={200} />;
+};
+
+const Template: Story<ModalPopupAreaProps> = (args) => (
+  <ModalPopupArea {...args}>
+    <TestModalContent />
+  </ModalPopupArea>
+);
+
+export const TestModalPopupArea = Template.bind({});
+TestModalPopupArea.args = {
+  modalOpen: true,
+  onModalClose: action('onClick'),
+};

--- a/client/src/components/UI/molecules/ModalPopupArea/ModalPopupArea.tsx
+++ b/client/src/components/UI/molecules/ModalPopupArea/ModalPopupArea.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Dialog, makeStyles } from '@material-ui/core';
+
+interface ModalPopupAreaProps {
+  modalOpen: boolean;
+  onModalClose: () => void;
+  children: React.ReactChild;
+}
+
+const useStyles = makeStyles({
+  root: {
+    '& .MuiPaper-rounded': {
+      borderRadius: 16,
+    },
+  },
+});
+
+const ModalPopupArea = ({ modalOpen, onModalClose, children }: ModalPopupAreaProps): JSX.Element => {
+  const classes = useStyles();
+
+  return (
+    <Dialog className={classes.root} open={modalOpen} onClose={onModalClose} aria-labelledby="form-dialog-title">
+      {children}
+    </Dialog>
+  );
+};
+
+export { ModalPopupArea };
+export type { ModalPopupAreaProps };

--- a/client/src/components/UI/molecules/TimeTableModalContent/TimeTableModalContent.stories.tsx
+++ b/client/src/components/UI/molecules/TimeTableModalContent/TimeTableModalContent.stories.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import { action } from '@storybook/addon-actions';
+import { withStoryBox } from '@/components/HOC';
+import { TimeTableModalContent, TimeTableModalType, TimeTableModalContentProps } from './TimeTableModalContent';
+
+export default {
+  title: 'molecules/TimeTableModalContent',
+  component: TimeTableModalContent,
+  decorators: [withKnobs],
+} as Meta;
+
+const Template: Story<TimeTableModalContentProps> = (args) => {
+  const TimeTableModalContentStory = withStoryBox(args, 300)(TimeTableModalContent);
+  return <TimeTableModalContentStory />;
+};
+
+export const tapAddModalContent = Template.bind({});
+tapAddModalContent.args = {
+  modalType: TimeTableModalType.TAB_ADD_MODAL,
+  onModalClose: action('onClick'),
+};
+
+export const tapRemoveModalContent = Template.bind({});
+tapRemoveModalContent.args = {
+  modalType: TimeTableModalType.TAB_REMOVE_MODAL,
+  onModalClose: action('onClick'),
+};

--- a/client/src/components/UI/molecules/TimeTableModalContent/TimeTableModalContent.tsx
+++ b/client/src/components/UI/molecules/TimeTableModalContent/TimeTableModalContent.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Button, DialogTitle, DialogContent, DialogActions, TextField } from '@material-ui/core';
+
+enum TimeTableModalType {
+  TAB_ADD_MODAL = 'TAB_ADD_MODAL',
+  TAB_REMOVE_MODAL = 'TAB_REMOVE_MODAL',
+}
+
+interface TimeTableModalContentProps {
+  modalType: TimeTableModalType;
+  onModalClose?: () => void;
+}
+
+const MODAL_TITLE = {
+  [TimeTableModalType.TAB_ADD_MODAL]: '시간표 탭 추가',
+  [TimeTableModalType.TAB_REMOVE_MODAL]: '시간표 탭 삭제',
+};
+const TAB_INPUT_LABEL = '탭 이름';
+const SUBMIT_BTN_NAME = {
+  [TimeTableModalType.TAB_ADD_MODAL]: '추가',
+  [TimeTableModalType.TAB_REMOVE_MODAL]: '삭제',
+};
+
+const TimeTableModalContent = ({ modalType, onModalClose }: TimeTableModalContentProps): JSX.Element => {
+  const isTabAddModal = (timeTablemodalType: TimeTableModalType): boolean => timeTablemodalType === TimeTableModalType.TAB_ADD_MODAL;
+
+  const getTextField = (timeTablemodalType: TimeTableModalType): JSX.Element | null => {
+    if (isTabAddModal(timeTablemodalType)) {
+      return <TextField autoFocus margin="dense" id="name" label={TAB_INPUT_LABEL} type="email" fullWidth />;
+    }
+    return null;
+  };
+
+  const onModalCloseListener = () => {
+    if (onModalClose) onModalClose();
+  };
+
+  return (
+    <>
+      <DialogTitle id="form-dialog-title">{MODAL_TITLE[modalType]}</DialogTitle>
+      <DialogContent>{getTextField(modalType)}</DialogContent>
+      <DialogActions>
+        <Button onClick={onModalCloseListener} color="primary">
+          {SUBMIT_BTN_NAME[modalType]}
+        </Button>
+      </DialogActions>
+    </>
+  );
+};
+
+export { TimeTableModalContent, TimeTableModalType };
+export type { TimeTableModalContentProps };

--- a/client/src/components/UI/molecules/index.ts
+++ b/client/src/components/UI/molecules/index.ts
@@ -5,3 +5,7 @@ export { Notice } from './Notice/Notice';
 export { SelectTab } from './Timetable/SelectTab/SelectTab';
 export { SearchBar } from './SearchBar/SearchBar';
 export { SearchResults } from './SearchResults/SearchResults';
+export { ModalPopupArea } from './ModalPopupArea/ModalPopupArea';
+export type { ModalPopupAreaProps } from './ModalPopupArea/ModalPopupArea';
+export { TimeTableModalContent, TimeTableModalType } from './TimeTableModalContent/TimeTableModalContent';
+export type { TimeTableModalContentProps } from './TimeTableModalContent/TimeTableModalContent';

--- a/client/src/components/UI/organisms/ModalPopup/ModalPopup.tsx
+++ b/client/src/components/UI/organisms/ModalPopup/ModalPopup.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { TimeTableModalType } from '@/components/UI/molecules';
+import { useStores } from '@/stores';
+import { useReactiveVar } from '@apollo/client';
+import { TimeTableModalPopup } from './TimeTableModalPopup';
+
+const ModalPopup = (): JSX.Element => {
+  const { modalStore } = useStores();
+  const { modalState, modalType } = modalStore.state;
+  const nowModalState = useReactiveVar(modalState);
+  const nowModalType = useReactiveVar(modalType);
+
+  const onModalCloseListener = () => {
+    alert('close');
+  };
+
+  const onTabAddModalBtnClickListener = () => {
+    alert('add');
+  };
+
+  const onTabRemoveModalBtnClickListener = () => {
+    alert('remove');
+  };
+
+  const getModalPopup = (): JSX.Element => {
+    if (nowModalType === TimeTableModalType.TAB_ADD_MODAL)
+      return (
+        <TimeTableModalPopup
+          modalOpen={nowModalState}
+          modalType={nowModalType}
+          onModalBtnClick={onTabAddModalBtnClickListener}
+          onModalAreaClose={onModalCloseListener}
+        />
+      );
+    return (
+      <TimeTableModalPopup
+        modalOpen={nowModalState}
+        modalType={nowModalType}
+        onModalBtnClick={onTabRemoveModalBtnClickListener}
+        onModalAreaClose={onModalCloseListener}
+      />
+    );
+  };
+
+  return <>{getModalPopup()}</>;
+};
+
+export { ModalPopup };

--- a/client/src/components/UI/organisms/ModalPopup/TimeTableModalPopup.stories.tsx
+++ b/client/src/components/UI/organisms/ModalPopup/TimeTableModalPopup.stories.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import { action } from '@storybook/addon-actions';
+import { TimeTableModalType } from '@/components/UI/molecules';
+import { TimeTableModalPopup, TimeTableModalPopupProps } from './TimeTableModalPopup';
+
+export default {
+  title: 'organisms/TimeTableModalPopup',
+  component: TimeTableModalPopup,
+  decorators: [withKnobs],
+} as Meta;
+
+const Template: Story<TimeTableModalPopupProps> = (args) => <TimeTableModalPopup {...args} />;
+
+export const TabAddModalPopup = Template.bind({});
+TabAddModalPopup.args = {
+  modalOpen: true,
+  modalType: TimeTableModalType.TAB_ADD_MODAL,
+  onModalAreaClose: action('onClick'),
+  onModalBtnClick: action('onClick'),
+};
+
+export const TabRemoveModalPopup = Template.bind({});
+TabRemoveModalPopup.args = {
+  modalOpen: true,
+  modalType: TimeTableModalType.TAB_REMOVE_MODAL,
+  onModalAreaClose: action('onClick'),
+  onModalBtnClick: action('onClick'),
+};

--- a/client/src/components/UI/organisms/ModalPopup/TimeTableModalPopup.tsx
+++ b/client/src/components/UI/organisms/ModalPopup/TimeTableModalPopup.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { ModalPopupArea, TimeTableModalContent, TimeTableModalType } from '@/components/UI/molecules';
+
+interface TimeTableModalPopupProps {
+  modalOpen: boolean;
+  modalType: TimeTableModalType;
+  onModalAreaClose: () => void;
+  onModalBtnClick: () => void;
+}
+
+const TimeTableModalPopup = ({ modalOpen, modalType, onModalAreaClose, onModalBtnClick }: TimeTableModalPopupProps): JSX.Element => {
+  return (
+    <ModalPopupArea modalOpen={modalOpen} onModalClose={onModalAreaClose}>
+      <TimeTableModalContent modalType={modalType} onModalClose={onModalBtnClick} />
+    </ModalPopupArea>
+  );
+};
+
+export { TimeTableModalPopup };
+export type { TimeTableModalPopupProps };

--- a/client/src/components/UI/organisms/index.ts
+++ b/client/src/components/UI/organisms/index.ts
@@ -1,2 +1,1 @@
-export { MainLeft } from './MainLeft/MainLeft';
 export { ModalPopup } from './ModalPopup/ModalPopup';

--- a/client/src/components/UI/organisms/index.ts
+++ b/client/src/components/UI/organisms/index.ts
@@ -1,0 +1,2 @@
+export { MainLeft } from './MainLeft/MainLeft';
+export { ModalPopup } from './ModalPopup/ModalPopup';

--- a/client/src/stores/ModalStore.ts
+++ b/client/src/stores/ModalStore.ts
@@ -1,14 +1,10 @@
 import { makeVar, ReactiveVar } from '@apollo/client';
 import { RootStore } from '@/stores';
-
-enum ModalType {
-  TAB_ADD_MODAL = 'TAB_ADD_MODAL',
-  TAB_REMOVE_MODAL = 'TAB_REMOVE_MODAL',
-}
+import { TimeTableModalType } from '@/components/UI/molecules';
 
 interface ModalStoreState {
   modalState: ReactiveVar<boolean>;
-  modalType: ReactiveVar<ModalType>;
+  modalType: ReactiveVar<TimeTableModalType>;
 }
 
 class ModalStore {
@@ -20,16 +16,16 @@ class ModalStore {
     this.rootStore = rootStore;
     this.state = {
       modalState: makeVar<boolean>(false),
-      modalType: makeVar<ModalType>(ModalType.TAB_ADD_MODAL),
+      modalType: makeVar<TimeTableModalType>(TimeTableModalType.TAB_ADD_MODAL),
     };
   }
 
-  changeModalState(newModalType: ModalType, newModalState: boolean): void {
+  changeModalState(newModalType: TimeTableModalType, newModalState: boolean): void {
     this.setModalType(newModalType);
     this.setModalState(newModalState);
   }
 
-  setModalType(newModalType: ModalType): void {
+  setModalType(newModalType: TimeTableModalType): void {
     const { modalType } = this.state;
 
     if (modalType() === newModalType) return;


### PR DESCRIPTION
## 📑 제목

#29 Modal 컴포넌트 수정 작업


## 💬 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] **모달 UI 컴포넌트 제작 작업**
  - **ModalPopupArea 컴포넌트 제작** 
     - 모달 레이아웃만 구성하고, 모달 컨텐츠는 외부에서 children으로 주입받도록 제작
![image](https://user-images.githubusercontent.com/32856129/111961922-fdf23000-8b34-11eb-8e73-8fa650aab451.png)
  - **TimeTableModalContent 컴포넌트 제작**
     - 시간표 추가 추가 모달 컨텐츠
![image](https://user-images.githubusercontent.com/32856129/111962217-60e3c700-8b35-11eb-9e50-411f583bf3ec.png)
     - 시간표 삭제 모달 컨텐츠
![image](https://user-images.githubusercontent.com/32856129/111962261-722cd380-8b35-11eb-9596-f31d18f0cf62.png)
  - **TimeTableModalPopup 컴포넌트 제작**
     - 시간표 탭 추가 모달
![image](https://user-images.githubusercontent.com/32856129/111962661-ecf5ee80-8b35-11eb-8221-0e7c039dcf75.png)
     - 시간표 탭 삭제 모달
![image](https://user-images.githubusercontent.com/32856129/111962698-fa12dd80-8b35-11eb-82a5-44ed729044ef.png)
- [x] **Modal 컴포넌트 스토리 작성**
- [x] **스토리북에서 store와 연동하여 테스팅하기 위해 StoreProvider를 스토리북에 Wrapping 작업**
- [x] **모달관련 비즈니스 로직을 정의할 ModalPopup 컴포넌트 제작 작업**
     - PR 머지 후에 작업을 진행하기 위해 기초 구조만 작성해둔 상태입니다.
- [x] **withStoryBox HOC 제작**
     - 스토리북 테스팅시 컴포넌트의 width가 100%이거나 컴포넌트의 children이 존재하지않아서 width가 설정되지 않아 스토리북화면에 제대로 보이지 않은 현상이 존재합니다.
     - 매번 스토리 작성시 wrapper 컴포넌트를 작성해서 width를 설정하는 작업은 번거로우니 withStoryBox HOC로 제작하였습니다! 스토리북 화면에 적절한 사이즈로 보일 수 있도록 필요한 경우 사용해주세용!


## 🚧 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- PR 머지 후에 진혁님께서 수정해주신 메인페이지 레이아웃을 참조하여 기존 모달 제거 및 ModalStore와의 연동작업을 진행할게요 :)
- 컴포넌트 제작시에 Props의 네이밍 작업이 생각보다 힘드네용 ㅠ 명확하게 짓고 싶은데 해당 부분은 계속 수정해보겠습니다. 물론 네이밍 추천도 환영입니다!