### PR TITLE
TimeTableMenu 컴포넌트 제작 및 ModalStore 연동

### DIFF
--- a/client/src/components/UI/molecules/TimeTableModalContent/TimeTableModalContent.tsx
+++ b/client/src/components/UI/molecules/TimeTableModalContent/TimeTableModalContent.tsx
@@ -11,14 +11,16 @@ interface TimeTableModalContentProps {
   onModalClose?: () => void;
 }
 
-const MODAL_TITLE = {
-  [TimeTableModalType.TAB_ADD_MODAL]: '시간표 탭 추가',
-  [TimeTableModalType.TAB_REMOVE_MODAL]: '시간표 탭 삭제',
-};
-const TAB_INPUT_LABEL = '탭 이름';
-const SUBMIT_BTN_NAME = {
-  [TimeTableModalType.TAB_ADD_MODAL]: '추가',
-  [TimeTableModalType.TAB_REMOVE_MODAL]: '삭제',
+const MODAL_INFO = {
+  [TimeTableModalType.TAB_ADD_MODAL]: {
+    TITLE: '시간표 탭을 추가할까요?',
+    TAB_LABLE: '탭 이름',
+    SUBNIT_BTN_NAME: '추가',
+  },
+  [TimeTableModalType.TAB_REMOVE_MODAL]: {
+    TITLE: '시간표 탭을 삭제할까요?',
+    SUBNIT_BTN_NAME: '삭제',
+  },
 };
 
 const TimeTableModalContent = ({ modalType, onModalClose }: TimeTableModalContentProps): JSX.Element => {
@@ -26,7 +28,7 @@ const TimeTableModalContent = ({ modalType, onModalClose }: TimeTableModalConten
 
   const getTextField = (timeTablemodalType: TimeTableModalType): JSX.Element | null => {
     if (isTabAddModal(timeTablemodalType)) {
-      return <TextField autoFocus margin="dense" id="name" label={TAB_INPUT_LABEL} type="email" fullWidth />;
+      return <TextField autoFocus margin="dense" id="name" label={MODAL_INFO[TimeTableModalType.TAB_ADD_MODAL].TAB_LABLE} type="email" fullWidth />;
     }
     return null;
   };
@@ -37,11 +39,11 @@ const TimeTableModalContent = ({ modalType, onModalClose }: TimeTableModalConten
 
   return (
     <>
-      <DialogTitle id="form-dialog-title">{MODAL_TITLE[modalType]}</DialogTitle>
+      <DialogTitle id="form-dialog-title">{MODAL_INFO[modalType].TITLE}</DialogTitle>
       <DialogContent>{getTextField(modalType)}</DialogContent>
       <DialogActions>
         <Button onClick={onModalCloseListener} color="primary">
-          {SUBMIT_BTN_NAME[modalType]}
+          {MODAL_INFO[modalType].SUBNIT_BTN_NAME}
         </Button>
       </DialogActions>
     </>

--- a/client/src/components/UI/molecules/TimeTableTabBtnGroup/TimeTableTabBtnGroup.stories.tsx
+++ b/client/src/components/UI/molecules/TimeTableTabBtnGroup/TimeTableTabBtnGroup.stories.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import { action } from '@storybook/addon-actions';
+import { TimeTableTabBtnGroup, TimeTableTabBtnGroupProps } from './TimeTableTabBtnGroup';
+
+export default {
+  title: 'molecules/TimeTableTabBtnGroup',
+  component: TimeTableTabBtnGroup,
+  decorators: [withKnobs],
+} as Meta;
+
+const Template: Story<TimeTableTabBtnGroupProps> = (args) => <TimeTableTabBtnGroup {...args} />;
+
+export const defaultTimeTableTabBtnGroup = Template.bind({});
+defaultTimeTableTabBtnGroup.args = {
+  onTabAddBtnClick: action('onClick'),
+  onTabRemoveBtnClick: action('onClick'),
+};

--- a/client/src/components/UI/molecules/TimeTableTabBtnGroup/TimeTableTabBtnGroup.tsx
+++ b/client/src/components/UI/molecules/TimeTableTabBtnGroup/TimeTableTabBtnGroup.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Box, Tooltip, IconButton } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import AddCircleTwoToneIcon from '@material-ui/icons/AddCircleTwoTone';
+import DeleteIcon from '@material-ui/icons/Delete';
+
+interface TimeTableTabBtnGroupProps {
+  onTabAddBtnClick: () => void;
+  onTabRemoveBtnClick: () => void;
+}
+
+const useStyles = makeStyles({
+  buttons: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    width: '25%',
+  },
+});
+
+const TimeTableTabBtnGroup = ({ onTabAddBtnClick, onTabRemoveBtnClick }: TimeTableTabBtnGroupProps): JSX.Element => {
+  const classes = useStyles();
+  return (
+    <Box className={classes.buttons}>
+      <Tooltip title="시간표 추가" onClick={onTabAddBtnClick}>
+        <IconButton aria-label="add">
+          <AddCircleTwoToneIcon color="primary" />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="시간표 삭제" onClick={onTabRemoveBtnClick}>
+        <IconButton aria-label="delete">
+          <DeleteIcon color="primary" />
+        </IconButton>
+      </Tooltip>
+    </Box>
+  );
+};
+
+export { TimeTableTabBtnGroup };
+export type { TimeTableTabBtnGroupProps };

--- a/client/src/components/UI/molecules/TimeTableTabMenu/TimeTableTabMenu.stories.tsx
+++ b/client/src/components/UI/molecules/TimeTableTabMenu/TimeTableTabMenu.stories.tsx
@@ -16,26 +16,26 @@ export const defaultTimeTableTabMenu = Template.bind({});
 defaultTimeTableTabMenu.args = {
   tables: [
     {
-      index: 0,
+      index: 1,
       name: '시간표1',
     },
     {
-      index: 1,
+      index: 2,
       name: '시간표2',
     },
     {
-      index: 2,
+      index: 3,
       name: '시간표3',
     },
     {
-      index: 3,
+      index: 4,
       name: '시간표4',
     },
     {
-      index: 4,
+      index: 5,
       name: '시간표5',
     },
   ],
-  seletedTab: 0,
+  seletedTab: 1,
   onTimeTableTabChange: action('onClick'),
 };

--- a/client/src/components/UI/molecules/TimeTableTabMenu/TimeTableTabMenu.stories.tsx
+++ b/client/src/components/UI/molecules/TimeTableTabMenu/TimeTableTabMenu.stories.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import { action } from '@storybook/addon-actions';
+import { TimeTableTabMenu, TimeTableTabMenuProps } from './TimeTableTabMenu';
+
+export default {
+  title: 'molecules/TimeTableTabMenu',
+  component: TimeTableTabMenu,
+  decorators: [withKnobs],
+} as Meta;
+
+const Template: Story<TimeTableTabMenuProps> = (args) => <TimeTableTabMenu {...args} />;
+
+export const defaultTimeTableTabMenu = Template.bind({});
+defaultTimeTableTabMenu.args = {
+  tables: [
+    {
+      index: 0,
+      name: '시간표1',
+    },
+    {
+      index: 1,
+      name: '시간표2',
+    },
+    {
+      index: 2,
+      name: '시간표3',
+    },
+    {
+      index: 3,
+      name: '시간표4',
+    },
+    {
+      index: 4,
+      name: '시간표5',
+    },
+  ],
+  seletedTab: 0,
+  onTimeTableTabChange: action('onClick'),
+};

--- a/client/src/components/UI/molecules/TimeTableTabMenu/TimeTableTabMenu.tsx
+++ b/client/src/components/UI/molecules/TimeTableTabMenu/TimeTableTabMenu.tsx
@@ -26,8 +26,9 @@ const useStyles = makeStyles((theme) => ({
     backgroundColor: theme.palette.background.paper,
   },
   tab: {
-    '& .MuiTab-root': {
-      minWidth: '6.25rem',
+    width: '6.875rem',
+    '@media (min-width: 600px)': {
+      minWidth: '6.875rem !important',
     },
   },
   tabHead: {

--- a/client/src/components/UI/molecules/TimeTableTabMenu/TimeTableTabMenu.tsx
+++ b/client/src/components/UI/molecules/TimeTableTabMenu/TimeTableTabMenu.tsx
@@ -1,0 +1,63 @@
+/* eslint-disable react/jsx-closing-bracket-location */
+import React from 'react';
+import { Tabs, Tab } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    width: '30rem',
+  },
+  tabs: {
+    display: 'flex',
+    width: '75%',
+    backgroundColor: theme.palette.background.paper,
+  },
+  tabHead: {
+    display: 'none',
+  },
+}));
+
+interface TableInfo {
+  name: string;
+  index: number;
+}
+
+interface TimeTableTabMenuProps {
+  tables: Array<TableInfo>;
+  seletedTab: number;
+  onTimeTableTabChange: () => void;
+}
+
+const TabProps = (index: number) => {
+  return {
+    id: `scrollable-auto-tab-${index}`,
+    'aria-controls': `scrollable-auto-tabpanel-${index}`,
+  };
+};
+
+const TimeTableTabMenu = ({ tables, seletedTab, onTimeTableTabChange }: TimeTableTabMenuProps): JSX.Element => {
+  const classes = useStyles();
+
+  const fillTable = () => {
+    return tables.map((table) => <Tab label={table.name} {...TabProps(table.index)} />);
+  };
+
+  return (
+    <Tabs
+      value={seletedTab}
+      onChange={onTimeTableTabChange}
+      indicatorColor="primary"
+      textColor="primary"
+      variant="scrollable"
+      scrollButtons="auto"
+      aria-label="timetable select tabs">
+      <Tab className={classes.tabHead} label="" {...TabProps(0)} />
+      {fillTable()}
+    </Tabs>
+  );
+};
+
+export { TimeTableTabMenu };
+export type { TimeTableTabMenuProps };

--- a/client/src/components/UI/molecules/TimeTableTabMenu/TimeTableTabMenu.tsx
+++ b/client/src/components/UI/molecules/TimeTableTabMenu/TimeTableTabMenu.tsx
@@ -3,22 +3,6 @@ import React from 'react';
 import { Tabs, Tab } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    width: '30rem',
-  },
-  tabs: {
-    display: 'flex',
-    width: '75%',
-    backgroundColor: theme.palette.background.paper,
-  },
-  tabHead: {
-    display: 'none',
-  },
-}));
-
 interface TableInfo {
   name: string;
   index: number;
@@ -30,18 +14,39 @@ interface TimeTableTabMenuProps {
   onTimeTableTabChange: () => void;
 }
 
-const TabProps = (index: number) => {
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    width: '30rem',
+  },
+  tabs: {
+    display: 'flex',
+    width: '75%',
+    backgroundColor: theme.palette.background.paper,
+  },
+  tab: {
+    '& .MuiTab-root': {
+      minWidth: '6.25rem',
+    },
+  },
+  tabHead: {
+    display: 'none',
+  },
+}));
+
+const TabProps = (tabIndex: number) => {
   return {
-    id: `scrollable-auto-tab-${index}`,
-    'aria-controls': `scrollable-auto-tabpanel-${index}`,
+    id: `scrollable-auto-tab-${tabIndex}`,
+    'aria-controls': `scrollable-auto-tabpanel-${tabIndex}`,
   };
 };
 
 const TimeTableTabMenu = ({ tables, seletedTab, onTimeTableTabChange }: TimeTableTabMenuProps): JSX.Element => {
   const classes = useStyles();
 
-  const fillTable = () => {
-    return tables.map((table) => <Tab label={table.name} {...TabProps(table.index)} />);
+  const getTabs = () => {
+    return tables.map((table) => <Tab className={classes.tab} label={table.name} {...TabProps(table.index)} />);
   };
 
   return (
@@ -54,7 +59,7 @@ const TimeTableTabMenu = ({ tables, seletedTab, onTimeTableTabChange }: TimeTabl
       scrollButtons="auto"
       aria-label="timetable select tabs">
       <Tab className={classes.tabHead} label="" {...TabProps(0)} />
-      {fillTable()}
+      {getTabs()}
     </Tabs>
   );
 };

--- a/client/src/components/UI/molecules/index.ts
+++ b/client/src/components/UI/molecules/index.ts
@@ -9,3 +9,7 @@ export { ModalPopupArea } from './ModalPopupArea/ModalPopupArea';
 export type { ModalPopupAreaProps } from './ModalPopupArea/ModalPopupArea';
 export { TimeTableModalContent, TimeTableModalType } from './TimeTableModalContent/TimeTableModalContent';
 export type { TimeTableModalContentProps } from './TimeTableModalContent/TimeTableModalContent';
+export { TimeTableTabBtnGroup } from './TimeTableTabBtnGroup/TimeTableTabBtnGroup';
+export type { TimeTableTabBtnGroupProps } from './TimeTableTabBtnGroup/TimeTableTabBtnGroup';
+export { TimeTableTabMenu } from './TimeTableTabMenu/TimeTableTabMenu';
+export type { TimeTableTabMenuProps } from './TimeTableTabMenu/TimeTableTabMenu';

--- a/client/src/components/UI/organisms/ModalPopup/ModalPopup.tsx
+++ b/client/src/components/UI/organisms/ModalPopup/ModalPopup.tsx
@@ -11,15 +11,17 @@ const ModalPopup = (): JSX.Element => {
   const nowModalType = useReactiveVar(modalType);
 
   const onModalCloseListener = () => {
-    alert('close');
+    modalStore.setModalState(false);
   };
 
   const onTabAddModalBtnClickListener = () => {
     alert('add');
+    modalStore.setModalState(false);
   };
 
   const onTabRemoveModalBtnClickListener = () => {
     alert('remove');
+    modalStore.setModalState(false);
   };
 
   const getModalPopup = (): JSX.Element => {

--- a/client/src/components/UI/organisms/TimeTableMenu/TimeTableMenu.tsx
+++ b/client/src/components/UI/organisms/TimeTableMenu/TimeTableMenu.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { useStores } from '@/stores';
+import { TimeTableModalType } from '@/components/UI/molecules';
+import { TimeTableMenuArea } from './TimeTableMenuArea';
+
+const TimeTableMenu = (): JSX.Element => {
+  const { modalStore } = useStores();
+
+  const mockTables = [
+    {
+      index: 1,
+      name: '시간표1',
+    },
+    {
+      index: 2,
+      name: '시간표2',
+    },
+    {
+      index: 3,
+      name: '시간표3',
+    },
+    {
+      index: 4,
+      name: '시간표4',
+    },
+    {
+      index: 5,
+      name: '시간표5',
+    },
+  ];
+
+  const mockSeletedTab = 1;
+
+  const onTimeTableTabChangeListener = (): void => {
+    alert('onTimeTableTabChangeListener');
+  };
+
+  const onTabAddBtnClickListener = () => {
+    modalStore.changeModalState(TimeTableModalType.TAB_ADD_MODAL, true);
+  };
+
+  const onTabRemoveBtnClickListener = () => {
+    modalStore.changeModalState(TimeTableModalType.TAB_REMOVE_MODAL, true);
+  };
+
+  return (
+    <TimeTableMenuArea
+      tables={mockTables}
+      seletedTab={mockSeletedTab}
+      onTimeTableTabChange={onTimeTableTabChangeListener}
+      onTabAddBtnClick={onTabAddBtnClickListener}
+      onTabRemoveBtnClick={onTabRemoveBtnClickListener}
+    />
+  );
+};
+
+export { TimeTableMenu };

--- a/client/src/components/UI/organisms/TimeTableMenu/TimeTableMenuArea.stories.tsx
+++ b/client/src/components/UI/organisms/TimeTableMenu/TimeTableMenuArea.stories.tsx
@@ -36,7 +36,7 @@ TimeTableMenu.args = {
       name: '시간표5',
     },
   ],
-  seletedTab: 0,
+  seletedTab: 1,
   onTimeTableTabChange: action('onClick'),
   onTabAddBtnClick: action('onClick'),
   onTabRemoveBtnClick: action('onClick'),

--- a/client/src/components/UI/organisms/TimeTableMenu/TimeTableMenuArea.stories.tsx
+++ b/client/src/components/UI/organisms/TimeTableMenu/TimeTableMenuArea.stories.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import { action } from '@storybook/addon-actions';
+import { TimeTableMenuArea, TimeTableMenuAreaProps } from './TimeTableMenuArea';
+
+export default {
+  title: 'organisms/TimeTableMenu',
+  component: TimeTableMenuArea,
+  decorators: [withKnobs],
+} as Meta;
+
+const Template: Story<TimeTableMenuAreaProps> = (args) => <TimeTableMenuArea {...args} />;
+
+export const TimeTableMenu = Template.bind({});
+TimeTableMenu.args = {
+  tables: [
+    {
+      index: 1,
+      name: '시간표1',
+    },
+    {
+      index: 2,
+      name: '시간표2',
+    },
+    {
+      index: 3,
+      name: '시간표3',
+    },
+    {
+      index: 4,
+      name: '시간표4',
+    },
+    {
+      index: 5,
+      name: '시간표5',
+    },
+  ],
+  seletedTab: 0,
+  onTimeTableTabChange: action('onClick'),
+  onTabAddBtnClick: action('onClick'),
+  onTabRemoveBtnClick: action('onClick'),
+};

--- a/client/src/components/UI/organisms/TimeTableMenu/TimeTableMenuArea.tsx
+++ b/client/src/components/UI/organisms/TimeTableMenu/TimeTableMenuArea.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Box } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import { TimeTableTabMenu, TimeTableTabMenuProps, TimeTableTabBtnGroup, TimeTableTabBtnGroupProps } from '@/components/UI/molecules';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    width: '30rem',
+    marginBottom: '0.3125rem',
+  },
+  tabs: {
+    display: 'flex',
+    width: '75%',
+    backgroundColor: theme.palette.background.paper,
+  },
+}));
+
+interface TimeTableMenuAreaProps extends TimeTableTabMenuProps, TimeTableTabBtnGroupProps {}
+
+const TimeTableMenuArea = ({
+  tables,
+  seletedTab,
+  onTimeTableTabChange,
+  onTabAddBtnClick,
+  onTabRemoveBtnClick,
+}: TimeTableMenuAreaProps): JSX.Element => {
+  const classes = useStyles();
+
+  return (
+    <Box className={classes.root} component="div">
+      <Box className={classes.tabs} component="div">
+        <TimeTableTabMenu tables={tables} seletedTab={seletedTab} onTimeTableTabChange={onTimeTableTabChange} />
+      </Box>
+      <TimeTableTabBtnGroup onTabAddBtnClick={onTabAddBtnClick} onTabRemoveBtnClick={onTabRemoveBtnClick} />
+    </Box>
+  );
+};
+
+export { TimeTableMenuArea };
+export type { TimeTableMenuAreaProps };

--- a/client/src/components/UI/organisms/index.ts
+++ b/client/src/components/UI/organisms/index.ts
@@ -1,1 +1,2 @@
 export { ModalPopup } from './ModalPopup/ModalPopup';
+export { TimeTableMenu } from './TimeTableMenu/TimeTableMenu';

--- a/client/src/components/pages/MainPage.tsx
+++ b/client/src/components/pages/MainPage.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { AlertSnackbar } from '@/components/UI/atoms';
-import { Header, Timetable, Notice, SelectTab, SearchResults } from '@/components/UI/molecules';
 import { Box, makeStyles } from '@material-ui/core';
+import { Header, Timetable, Notice, SearchResults } from '@/components/UI/molecules';
+import { ModalPopup, TimeTableMenu } from '@/components/UI/organisms';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles({
   root: {
     display: 'flex',
     justifyContent: 'center',
@@ -25,25 +26,28 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: 'column',
     width: '35rem',
   },
-}));
+});
 
 const MainPage = (): JSX.Element => {
   const classes = useStyles();
   return (
-    <Box className={classes.root}>
-      <Header />
-      <Box className={classes.wrapper}>
-        <Box className={classes.left}>
-          <Notice />
-          <SelectTab />
-          <Timetable row={10} containedSat={false} />
-        </Box>
-        <Box className={classes.right}>
-          <SearchResults />
+    <>
+      <Box className={classes.root} component="div">
+        <Header />
+        <Box className={classes.wrapper} component="div">
+          <Box className={classes.left} component="div">
+            <Notice />
+            <TimeTableMenu />
+            <Timetable row={10} containedSat={false} />
+          </Box>
+          <Box className={classes.right} component="div">
+            <SearchResults />
+          </Box>
         </Box>
       </Box>
       <AlertSnackbar />
-    </Box>
+      <ModalPopup />
+    </>
   );
 };
 


### PR DESCRIPTION
## 📑 제목

 #28, #31 TimeTableMenu 컴포넌트 제작 및 ModalStore 연동


## 💬 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] **TimeTableMenu 컴포넌트 제작**
      - 기존 Timetable 컴포넌트 폴더의 하위 폴더에 있던 SelectTab 컴포넌트를 별도의 컴포넌트로 분리하는 작업 진행
      - **TimeTableBtnGroup 컴포넌트**
![image](https://user-images.githubusercontent.com/32856129/112438123-03e14e80-8d8b-11eb-8b15-6eb85fd10e7f.png)
      - **TimeTableTabMenu 컴포넌트**
![image](https://user-images.githubusercontent.com/32856129/112438480-4f93f800-8d8b-11eb-8cd4-11944da7e638.png)
      - **TimeTableMenu 컴포넌트**
![image](https://user-images.githubusercontent.com/32856129/112438761-9da8fb80-8d8b-11eb-9b26-e90c6669368a.png)
- [x] TimeTableMenu 컴포넌트를 메인페이지 레이아웃에 추가
- [x] 메인페이지에서 모달 기능 동작을 위한 ModalStore 연동 작업
![ezgif com-gif-maker (31)](https://user-images.githubusercontent.com/32856129/112447573-d26d8080-8d94-11eb-91a7-76a51aca2239.gif)



## 🚧 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 

말하고 싶은 점

- 기존 SelectTab 컴포넌트는 안에 내부로직을 혹시 진혁님께서 참고하실 수 있을 것 같아서 삭제하지 않고 남겨놨습니다 :) 필요없다면 해당 컴포넌트는 삭제할게요!
- 스토리북 컴포넌트 네이밍은 일단 임시로 설정했습니다! 이전에 이야기한데로 기능 구현 후나 좋은 컨퍼런스가 있다면 추후에 수정해보아요!
- 시간표 탭 width를 수정하는 과정에서 material-UI Tab 컴포넌트가 미디어 쿼리가 적용되어있었습니다! 해당 스타일 제거하려면 미디어 쿼리를 덮어써야해서 임시로 미디어 쿼리를 추가했습니다!