### PR TITLE
로그인 모달 작업

### DIFF
--- a/client/src/components/UI/molecules/HeaderAuthSection/HeaderAuthSection.tsx
+++ b/client/src/components/UI/molecules/HeaderAuthSection/HeaderAuthSection.tsx
@@ -1,51 +1,15 @@
 import React from 'react';
-import { Box, Typography } from '@material-ui/core';
-import { Button, ButtonType } from '@/components/UI/atoms';
-import { makeStyles } from '@material-ui/core/styles';
-
-const useStyles = makeStyles((theme) => ({
-  loginSection: {
-    display: 'flex',
-    height: '5rem',
-    flexDirection: 'column',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  menu: {
-    display: 'flex',
-    justifyContent: 'center',
-  },
-  divider: {
-    borderLeft: `1px solid ${theme.palette.grey[500]}`,
-    margin: '0 3px',
-  },
-  authText: {
-    color: theme.palette.grey[600],
-  },
-  promotionText: {
-    color: theme.palette.grey[400],
-  },
-}));
+import { useStores } from '@/stores';
+import { modalTypes } from '@/components/UI/organisms';
+import { HeaderAuthSectionArea } from './HeaderAuthSectionArea';
 
 const HeaderAuthSection = (): JSX.Element => {
-  const classes = useStyles();
-  return (
-    <Box className={classes.loginSection}>
-      <Typography className={classes.promotionText} variant="caption">
-        한표를 더 편리하게 이용하세요
-      </Typography>
-      <Button btnType={ButtonType.login}>로 그 인</Button>
-      <Box className={classes.menu}>
-        <Typography className={classes.authText} variant="caption">
-          회 원 가 입
-        </Typography>
-        <Box className={classes.divider} />
-        <Typography className={classes.authText} variant="caption">
-          아 이 디 / 비 밀 번 호 찾기
-        </Typography>
-      </Box>
-    </Box>
-  );
+  const { modalStore } = useStores();
+
+  const onLoginBtnClickListener = () => {
+    modalStore.changeModalState(modalTypes.LOGIN_MODAL, true);
+  };
+  return <HeaderAuthSectionArea onClick={onLoginBtnClickListener} />;
 };
 
 export { HeaderAuthSection };

--- a/client/src/components/UI/molecules/HeaderAuthSection/HeaderAuthSectionArea.tsx
+++ b/client/src/components/UI/molecules/HeaderAuthSection/HeaderAuthSectionArea.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Box, Typography } from '@material-ui/core';
+import { Button, ButtonType } from '@/components/UI/atoms';
+import { makeStyles } from '@material-ui/core/styles';
+
+interface HeaderAuthSectionAreaProps {
+  onClick: () => void;
+}
+
+const useStyles = makeStyles((theme) => ({
+  loginSection: {
+    display: 'flex',
+    height: '5rem',
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  menu: {
+    display: 'flex',
+    justifyContent: 'center',
+  },
+  divider: {
+    borderLeft: `1px solid ${theme.palette.grey[500]}`,
+    margin: '0 3px',
+  },
+  authText: {
+    color: theme.palette.grey[600],
+  },
+  promotionText: {
+    color: theme.palette.grey[400],
+  },
+}));
+
+const HeaderAuthSectionArea = ({ onClick }: HeaderAuthSectionAreaProps): JSX.Element => {
+  const classes = useStyles();
+  return (
+    <Box className={classes.loginSection}>
+      <Typography className={classes.promotionText} variant="caption">
+        한표를 더 편리하게 이용하세요
+      </Typography>
+      <Button btnType={ButtonType.login} onClick={onClick}>
+        로 그 인
+      </Button>
+      <Box className={classes.menu}>
+        <Typography className={classes.authText} variant="caption">
+          회 원 가 입
+        </Typography>
+        <Box className={classes.divider} />
+        <Typography className={classes.authText} variant="caption">
+          아 이 디 / 비 밀 번 호 찾기
+        </Typography>
+      </Box>
+    </Box>
+  );
+};
+
+export { HeaderAuthSectionArea };

--- a/client/src/components/UI/molecules/LoginModalContent/LoginModalContent.stories.tsx
+++ b/client/src/components/UI/molecules/LoginModalContent/LoginModalContent.stories.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import { action } from '@storybook/addon-actions';
+import { withStoryBox } from '@/components/HOC';
+import { LoginModalContent, LoginModalType, LoginModalContentProps } from './LoginModalContent';
+
+export default {
+  title: 'molecules/LoginModalContent',
+  component: LoginModalContent,
+  decorators: [withKnobs],
+} as Meta;
+
+const Template: Story<LoginModalContentProps> = (args) => {
+  const LoginModalContentStory = withStoryBox(args, 300)(LoginModalContent);
+  return <LoginModalContentStory />;
+};
+
+export const loginModalContent = Template.bind({});
+loginModalContent.args = {
+  modalType: LoginModalType.LOGIN_MODAL,
+  onModalClose: action('onClick'),
+};

--- a/client/src/components/UI/molecules/LoginModalContent/LoginModalContent.tsx
+++ b/client/src/components/UI/molecules/LoginModalContent/LoginModalContent.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Button, DialogTitle, DialogContent, DialogActions, TextField } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 
 enum LoginModalType {
   LOGIN_MODAL = 'LOGIN_MODAL',
@@ -9,14 +10,32 @@ interface LoginModalContentProps {
   onModalClose: () => void;
 }
 
+const useStyles = makeStyles((theme) => ({
+  title: {
+    display: 'flex',
+    justifyContent: 'center',
+    fontSize: '1.7rem',
+    color: theme.palette.primary.main,
+  },
+}));
+
 const LoginModalContent = ({ onModalClose }: LoginModalContentProps): JSX.Element => {
+  const classes = useStyles();
+
   return (
     <>
-      <DialogTitle id="login-dialog-title">한표 로그인</DialogTitle>
+      <DialogTitle className={classes.title} id="login-dialog-title" disableTypography>
+        한표 로그인
+      </DialogTitle>
       <DialogContent>
         <TextField autoFocus margin="dense" id="id" label="아이디" type="email" fullWidth />
-        <TextField autoFocus margin="dense" id="password" label="비밀번호" type="password" fullWidth />
+        <TextField margin="dense" id="password" label="비밀번호" type="password" fullWidth />
       </DialogContent>
+      <DialogActions>
+        <Button onClick={onModalClose} color="primary">
+          로그인
+        </Button>
+      </DialogActions>
     </>
   );
 };

--- a/client/src/components/UI/molecules/LoginModalContent/LoginModalContent.tsx
+++ b/client/src/components/UI/molecules/LoginModalContent/LoginModalContent.tsx
@@ -41,3 +41,4 @@ const LoginModalContent = ({ onModalClose }: LoginModalContentProps): JSX.Elemen
 };
 
 export { LoginModalContent, LoginModalType };
+export type { LoginModalContentProps };

--- a/client/src/components/UI/molecules/LoginModalContent/LoginModalContent.tsx
+++ b/client/src/components/UI/molecules/LoginModalContent/LoginModalContent.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Button, DialogTitle, DialogContent, DialogActions, TextField } from '@material-ui/core';
+
+enum LoginModalType {
+  LOGIN_MODAL = 'LOGIN_MODAL',
+}
+
+interface LoginModalContentProps {
+  onModalClose: () => void;
+}
+
+const LoginModalContent = ({ onModalClose }: LoginModalContentProps): JSX.Element => {
+  return (
+    <>
+      <DialogTitle id="login-dialog-title">한표 로그인</DialogTitle>
+      <DialogContent>
+        <TextField autoFocus margin="dense" id="id" label="아이디" type="email" fullWidth />
+        <TextField autoFocus margin="dense" id="password" label="비밀번호" type="password" fullWidth />
+      </DialogContent>
+    </>
+  );
+};
+
+export { LoginModalContent, LoginModalType };

--- a/client/src/components/UI/molecules/TimeTableModalContent/TimeTableModalContent.tsx
+++ b/client/src/components/UI/molecules/TimeTableModalContent/TimeTableModalContent.tsx
@@ -14,21 +14,21 @@ interface TimeTableModalContentProps {
 const MODAL_INFO = {
   [TimeTableModalType.TAB_ADD_MODAL]: {
     TITLE: '시간표 탭을 추가할까요?',
-    TAB_LABLE: '탭 이름',
-    SUBNIT_BTN_NAME: '추가',
+    TAB_LABEL: '탭 이름',
+    SUBMIT_BTN_NAME: '추가',
   },
   [TimeTableModalType.TAB_REMOVE_MODAL]: {
     TITLE: '시간표 탭을 삭제할까요?',
-    SUBNIT_BTN_NAME: '삭제',
+    SUBMIT_BTN_NAME: '삭제',
   },
 };
 
 const TimeTableModalContent = ({ modalType, onModalClose }: TimeTableModalContentProps): JSX.Element => {
-  const isTabAddModal = (timeTablemodalType: TimeTableModalType): boolean => timeTablemodalType === TimeTableModalType.TAB_ADD_MODAL;
+  const isTabAddModal = (timeTableModalType: TimeTableModalType): boolean => timeTableModalType === TimeTableModalType.TAB_ADD_MODAL;
 
-  const getTextField = (timeTablemodalType: TimeTableModalType): JSX.Element | null => {
-    if (isTabAddModal(timeTablemodalType)) {
-      return <TextField autoFocus margin="dense" id="name" label={MODAL_INFO[TimeTableModalType.TAB_ADD_MODAL].TAB_LABLE} type="email" fullWidth />;
+  const getTextField = (timeTableModalType: TimeTableModalType): JSX.Element | null => {
+    if (isTabAddModal(timeTableModalType)) {
+      return <TextField autoFocus margin="dense" id="name" label={MODAL_INFO[TimeTableModalType.TAB_ADD_MODAL].TAB_LABEL} type="email" fullWidth />;
     }
     return null;
   };
@@ -43,7 +43,7 @@ const TimeTableModalContent = ({ modalType, onModalClose }: TimeTableModalConten
       <DialogContent>{getTextField(modalType)}</DialogContent>
       <DialogActions>
         <Button onClick={onModalCloseListener} color="primary">
-          {MODAL_INFO[modalType].SUBNIT_BTN_NAME}
+          {MODAL_INFO[modalType].SUBMIT_BTN_NAME}
         </Button>
       </DialogActions>
     </>

--- a/client/src/components/UI/molecules/TimeTableModalContent/TimeTableModalContent.tsx
+++ b/client/src/components/UI/molecules/TimeTableModalContent/TimeTableModalContent.tsx
@@ -33,16 +33,12 @@ const TimeTableModalContent = ({ modalType, onModalClose }: TimeTableModalConten
     return null;
   };
 
-  const onModalCloseListener = () => {
-    if (onModalClose) onModalClose();
-  };
-
   return (
     <>
       <DialogTitle id="form-dialog-title">{MODAL_INFO[modalType].TITLE}</DialogTitle>
       <DialogContent>{getTextField(modalType)}</DialogContent>
       <DialogActions>
-        <Button onClick={onModalCloseListener} color="primary">
+        <Button onClick={onModalClose} color="primary">
           {MODAL_INFO[modalType].SUBMIT_BTN_NAME}
         </Button>
       </DialogActions>

--- a/client/src/components/UI/molecules/index.ts
+++ b/client/src/components/UI/molecules/index.ts
@@ -17,3 +17,4 @@ export type { TimeTableTabMenuProps } from './TimeTableTabMenu/TimeTableTabMenu'
 export { LectureBoxContainer } from './LectureBoxContainer/LectureBoxContainer';
 export { BasketLectureListBody } from './LectureListBody/BasketLectureListBody';
 export { SearchedLectureListBody } from './LectureListBody/SearchedLectureListBody';
+export { LoginModalContent, LoginModalType } from './LoginModalContent/LoginModalContent';

--- a/client/src/components/UI/organisms/ModalPopup/LoginModalPopup.stories.tsx
+++ b/client/src/components/UI/organisms/ModalPopup/LoginModalPopup.stories.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import { action } from '@storybook/addon-actions';
+import { LoginModalType } from '@/components/UI/molecules';
+import { LoginModalPopup, LoginModalPopupProps } from './LoginModalPopup';
+
+export default {
+  title: 'organisms/LoginModalPopup',
+  component: LoginModalPopup,
+  decorators: [withKnobs],
+} as Meta;
+
+const Template: Story<LoginModalPopupProps> = (args) => <LoginModalPopup {...args} />;
+
+export const TabAddModalPopup = Template.bind({});
+TabAddModalPopup.args = {
+  modalOpen: true,
+  modalType: LoginModalType.LOGIN_MODAL,
+  onModalAreaClose: action('onClick'),
+  onModalBtnClick: action('onClick'),
+};

--- a/client/src/components/UI/organisms/ModalPopup/LoginModalPopup.tsx
+++ b/client/src/components/UI/organisms/ModalPopup/LoginModalPopup.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { ModalPopupArea, LoginModalContent } from '@/components/UI/molecules';
+
+interface LoginModalPopupProps {
+  modalOpen: boolean;
+  onModalAreaClose: () => void;
+  onModalBtnClick: () => void;
+}
+
+const LoginModalPopup = ({ modalOpen, onModalAreaClose, onModalBtnClick }: LoginModalPopupProps): JSX.Element => {
+  return (
+    <ModalPopupArea modalOpen={modalOpen} onModalClose={onModalAreaClose}>
+      <LoginModalContent onModalClose={onModalBtnClick} />
+    </ModalPopupArea>
+  );
+};
+
+export { LoginModalPopup };
+export type { LoginModalPopupProps };

--- a/client/src/components/UI/organisms/ModalPopup/ModalPopup.tsx
+++ b/client/src/components/UI/organisms/ModalPopup/ModalPopup.tsx
@@ -1,14 +1,20 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
 import React from 'react';
-import { TimeTableModalType } from '@/components/UI/molecules';
+import { TimeTableModalType, LoginModalType } from '@/components/UI/molecules';
 import { useStores } from '@/stores';
 import { useReactiveVar } from '@apollo/client';
 import { TimeTableModalPopup } from './TimeTableModalPopup';
+import { LoginModalPopup } from './LoginModalPopup';
+
+type ModalType = TimeTableModalType | LoginModalType;
+
+const modalTypes = { ...TimeTableModalType, ...LoginModalType };
 
 const ModalPopup = (): JSX.Element => {
   const { timeTableStore, modalStore } = useStores();
   const { modalState, modalType } = modalStore.state;
   const nowModalState = useReactiveVar(modalState);
-  const nowModalType = useReactiveVar(modalType);
+  const nowModalType = useReactiveVar<ModalType>(modalType);
 
   const onModalCloseListener = () => {
     modalStore.setModalState(false);
@@ -25,7 +31,7 @@ const ModalPopup = (): JSX.Element => {
   };
 
   const getModalPopup = (): JSX.Element => {
-    if (nowModalType === TimeTableModalType.TAB_ADD_MODAL)
+    if (nowModalType === modalTypes.TAB_ADD_MODAL)
       return (
         <TimeTableModalPopup
           modalOpen={nowModalState}
@@ -34,17 +40,20 @@ const ModalPopup = (): JSX.Element => {
           onModalAreaClose={onModalCloseListener}
         />
       );
-    return (
-      <TimeTableModalPopup
-        modalOpen={nowModalState}
-        modalType={nowModalType}
-        onModalBtnClick={onTabRemoveModalBtnClickListener}
-        onModalAreaClose={onModalCloseListener}
-      />
-    );
+    if (nowModalType === modalTypes.TAB_REMOVE_MODAL)
+      return (
+        <TimeTableModalPopup
+          modalOpen={nowModalState}
+          modalType={nowModalType}
+          onModalBtnClick={onTabRemoveModalBtnClickListener}
+          onModalAreaClose={onModalCloseListener}
+        />
+      );
+    return <LoginModalPopup modalOpen={nowModalState} onModalBtnClick={() => {}} onModalAreaClose={onModalCloseListener} />;
   };
 
   return <>{getModalPopup()}</>;
 };
 
-export { ModalPopup };
+export { ModalPopup, modalTypes };
+export type { ModalType };

--- a/client/src/components/UI/organisms/index.ts
+++ b/client/src/components/UI/organisms/index.ts
@@ -1,4 +1,5 @@
-export { ModalPopup } from './ModalPopup/ModalPopup';
+export { ModalPopup, modalTypes } from './ModalPopup/ModalPopup';
+export type { ModalType } from './ModalPopup/ModalPopup';
 export { LectureList } from './LectureList/LectureList';
 export type { LectureListProps } from './LectureList/LectureList';
 export { Header } from './Header/Header';

--- a/client/src/stores/ModalStore.ts
+++ b/client/src/stores/ModalStore.ts
@@ -1,10 +1,10 @@
 import { makeVar, ReactiveVar } from '@apollo/client';
 import { RootStore } from '@/stores';
-import { TimeTableModalType } from '@/components/UI/molecules';
+import { ModalType, modalTypes } from '@/components/UI/organisms';
 
 interface ModalStoreState {
   modalState: ReactiveVar<boolean>;
-  modalType: ReactiveVar<TimeTableModalType>;
+  modalType: ReactiveVar<ModalType>;
 }
 
 class ModalStore {
@@ -16,16 +16,16 @@ class ModalStore {
     this.rootStore = rootStore;
     this.state = {
       modalState: makeVar<boolean>(false),
-      modalType: makeVar<TimeTableModalType>(TimeTableModalType.TAB_ADD_MODAL),
+      modalType: makeVar<ModalType>(modalTypes.TAB_ADD_MODAL),
     };
   }
 
-  changeModalState(newModalType: TimeTableModalType, newModalState: boolean): void {
+  changeModalState(newModalType: ModalType, newModalState: boolean): void {
     this.setModalType(newModalType);
     this.setModalState(newModalState);
   }
 
-  setModalType(newModalType: TimeTableModalType): void {
+  setModalType(newModalType: ModalType): void {
     const { modalType } = this.state;
 
     if (modalType() === newModalType) return;


### PR DESCRIPTION
## 📑 제목

![image](https://user-images.githubusercontent.com/46101366/113853816-1458e680-97d9-11eb-8da4-c48dc0b376e4.png)

로그인창 모달 작업을 완료했습니다.

아직 버튼 클릭시 이벤트는 할당이 되지 않은 상태입니다. 백엔드쪽 작업이 완료되면 추가해주면 될 것 같습니다.

Type은 하위 컴포넌트들을 참조하는 방식으로 선언했습니다. union 타입을 활용했으며 enum 값에 접근하기 위해 어쩔 수 없이 새로운 변수를 하나 추가로 선언했습니다.

우진님이 작업하고 계신 것과 비슷한 방식으로 View와 비즈니스 로직을 분리하기 위해 HeaderLoginSection 부분에 HeaderLoginSectionArea를 추가했습니다.

## 💬 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 모달 관련 타입 설정
- [x] 로그인 모달 View 작업
- [x] HeaderAuthSection 리팩토링 (View, 비즈니스 로직 분리)


## 🚧 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점
