### PR TITLE
eslint 불필요한 옵션 off 작업

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -45,5 +45,10 @@ module.exports = {
     'no-shadow': 'off',
     '@typescript-eslint/no-shadow': 'error',
     'no-plusplus': 'off',
+    'react/jsx-wrap-multilines': 'off',
+    'jsx-a11y/no-noninteractive-element-interactions': 'off',
+    'jsx-a11y/no-static-element-interactions': 'off',
+    'jsx-a11y/click-events-have-key-events': 'off',
+    'react/jsx-closing-bracket-location': 'off',
   },
 };

--- a/client/src/components/UI/atoms/AlertSnackbar/AlertSnackbar.tsx
+++ b/client/src/components/UI/atoms/AlertSnackbar/AlertSnackbar.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-wrap-multilines */
 import React from 'react';
 import Snackbar from '@material-ui/core/Snackbar';
 import IconButton from '@material-ui/core/IconButton';

--- a/client/src/components/UI/atoms/SelectMenu/SelectMenu.tsx
+++ b/client/src/components/UI/atoms/SelectMenu/SelectMenu.tsx
@@ -1,8 +1,3 @@
-/* eslint-disable no-param-reassign */
-/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-/* eslint-disable react/jsx-closing-bracket-location */
 import React, { useState } from 'react';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import { Box, Popover } from '@material-ui/core';

--- a/client/src/components/UI/atoms/TimeSelectMenu/TimeSelectMenu.tsx
+++ b/client/src/components/UI/atoms/TimeSelectMenu/TimeSelectMenu.tsx
@@ -1,7 +1,3 @@
-/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-/* eslint-disable react/jsx-closing-bracket-location */
 import React, { useState } from 'react';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import { Box, Popover } from '@material-ui/core';

--- a/client/src/components/UI/molecules/SearchBar/SearchBar.tsx
+++ b/client/src/components/UI/molecules/SearchBar/SearchBar.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/no-distracting-elements */
 import React from 'react';
 import { InputBase } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';

--- a/client/src/components/UI/molecules/SubTitle/SubTitle.tsx
+++ b/client/src/components/UI/molecules/SubTitle/SubTitle.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/no-distracting-elements */
 import React from 'react';
 import { Typography, Divider, Box } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';

--- a/client/src/components/UI/molecules/TimeTableAddForm/TimeTableAddFormContent.tsx
+++ b/client/src/components/UI/molecules/TimeTableAddForm/TimeTableAddFormContent.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-closing-bracket-location */
 import React from 'react';
 import { Box, TextField } from '@material-ui/core';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';

--- a/client/src/components/UI/molecules/TimeTableTabMenu/TimeTableTabMenu.tsx
+++ b/client/src/components/UI/molecules/TimeTableTabMenu/TimeTableTabMenu.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-closing-bracket-location */
 import React from 'react';
 import { Tabs, Tab } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';


### PR DESCRIPTION
## 📑 제목

#54 eslint 불필요한 옵션 off 작업


## 💬 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 컴포넌트 파일에 있는 eslint 옵션 off 코드 제거
- [x] eslint 설정 파일에 불필요한 옵션 off하는 코드 추가
   - **react/jsx-wrap-multilines**
      - Props로 JSX Element를 전달하는 등 JSX Element를 여러 줄에 코드로 작성할 때, 괄호로 묶어줘야하는 옵션입니다. 불필요해 보이므로 off.
   - **jsx-a11y/no-noninteractive-element-interactions**
   - **jsx-a11y/no-static-element-interactions**
      - a 태그와 같이 사용자와 상호작용하는 태그가 아닌 요소에 onClick과 같은 이벤트를 지정할 때, 에러를 발생시키는 옵션입니다. 상호작용하는 요소에만 이벤트를 등록하는 것은 너무 제한적이라고 느껴져서 off.
   - **jsx-a11y/click-events-have-key-events**
      - onClick 이벤트 등록시 키보드 키이벤트(keyDown과 같은)를 이용해야하는 옵션인데.... 정말 불필요해보여서 off 했습니다.
   - **react/jsx-closing-bracket-location**
      - JSX Element 작성시 닫는 태그를 다음 줄에 작성해야만하는 옵션입니다. props가 길어지면 prettier와 충돌이 발생하여 off.

## 🚧 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 몇 가지 옵션은 아직 코드가 완성되지 않은 것 같아서 off 하지 않았습니다.
  - **LectureList 컴포넌트 파일 => @typescript-eslint/no-empty-function**
     - 빈 함수를 제한하는 옵션인데, 빈 함수는 의미가 없으므로 필요한 옵션이라고 생각이 드네요! off하지 않았습니다! LectureList 코드에서 props로 빈 함수를 전달하는데 아직 코드가 완성되지 않은 것일까요??
  - **Timetable 컴포넌트 파일 => no-continue**
     - no-continue 옵션은 사실 불필요해 보이기는 합니다! 다만 Timetable 로직 코드가 주석처리된 부분이 이전에 수정을 다 못한 부분이 존재해서 일단 보류했습니다.
  - **ModalPopup 컴포넌트 파일 => @typescript-eslint/no-empty-function**
     - 모달 부분도 아직 로그인 기능이 구현되지 않아서 빈 함수를 일단 props로 전달하는 것으로 보입니다