### PR TITLE
feat: color 랜덤 배정 기능 추가

### DIFF
--- a/client/src/components/UI/molecules/LectureBoxContainer/LectureBoxContainer.tsx
+++ b/client/src/components/UI/molecules/LectureBoxContainer/LectureBoxContainer.tsx
@@ -27,7 +27,7 @@ const LectureBoxContainer = (): JSX.Element => {
     return lectureInfos.map((elem) => {
       if (typeof elem.time === 'string') return <></>;
       return elem.time.map((time) => {
-        return <LectureBox startTime={time.start} endTime={time.end} name={elem.name} division={elem.class} prof={elem.prof} />;
+        return <LectureBox startTime={time.start} endTime={time.end} name={elem.name} division={elem.class} prof={elem.prof} bgcolor={elem.color} />;
       });
     });
   };

--- a/client/src/components/UI/molecules/LectureInfo/LectureInfo.tsx
+++ b/client/src/components/UI/molecules/LectureInfo/LectureInfo.tsx
@@ -50,6 +50,7 @@ interface LectureInfos {
   personnel: string;
   dept: string;
   time: Array<TimeTypes> | string;
+  color?: string;
 }
 
 interface LectureInfoProps {

--- a/client/src/stores/TimeTableStore.ts
+++ b/client/src/stores/TimeTableStore.ts
@@ -12,7 +12,27 @@ interface TimeTableStoreState {
   tables: ReactiveVar<TableInfo[]>;
   tableIndex: ReactiveVar<number>;
   lectures: ReactiveVar<Array<LectureInfos[]>>;
+  colorIndex: ReactiveVar<number>;
 }
+
+const colors = [
+  '#ff8a80',
+  '#ff80ab',
+  '#ea80fc',
+  '#b388ff',
+  '#8c9eff',
+  '#82b1ff',
+  '#80d8ff',
+  '#84ffff',
+  '#a7ffeb',
+  '#b9f6ca',
+  '#ccff90',
+  '#f4ff81',
+  '#ffff8d',
+  '#ffe57f',
+  '#ffd180',
+  '#ff9e80',
+];
 
 class TimeTableStore {
   rootStore: RootStore;
@@ -26,6 +46,7 @@ class TimeTableStore {
       tables: makeVar<TableInfo[]>([]),
       tableIndex: makeVar(0),
       lectures: makeVar<Array<LectureInfos[]>>([]),
+      colorIndex: makeVar<number>(Math.floor(Math.random() * colors.length)),
     };
   }
 
@@ -76,11 +97,13 @@ class TimeTableStore {
     if (!selectedTabIdx()) return;
     const isNoDuplicateLecture = lectures()[selectedTabIdx() - 1].every((curr) => curr.name !== input.name);
     if (!isNoDuplicateLecture) return;
-    const newLecture = [...lectures()[selectedTabIdx() - 1], input];
+    const inputWithColor = { ...input, color: this.getColor() };
+    const newLecture = [...lectures()[selectedTabIdx() - 1], inputWithColor];
     const newLectures = lectures().map((elem, idx) => {
       if (idx === selectedTabIdx() - 1) return newLecture;
       return elem;
     });
+    this.setNextColor();
     lectures(newLectures);
   }
 
@@ -97,6 +120,17 @@ class TimeTableStore {
   getLecturesFromTable(): LectureInfos[] {
     const { selectedTabIdx, lectures } = this.state;
     return lectures()[selectedTabIdx()];
+  }
+
+  setNextColor(): void {
+    const { colorIndex } = this.state;
+    const nextColorIndex = colorIndex() === colors.length - 1 ? 0 : colorIndex() + 1;
+    colorIndex(nextColorIndex);
+  }
+
+  getColor(): string {
+    const { colorIndex } = this.state;
+    return colors[colorIndex()];
   }
 }
 

--- a/client/src/stores/TimeTableStore.ts
+++ b/client/src/stores/TimeTableStore.ts
@@ -124,7 +124,7 @@ class TimeTableStore {
 
   setNextColor(): void {
     const { colorIndex } = this.state;
-    const nextColorIndex = colorIndex() === colors.length - 1 ? 0 : colorIndex() + 1;
+    const nextColorIndex = (colorIndex() + 1) % colors.length;
     colorIndex(nextColorIndex);
   }
 


### PR DESCRIPTION
## 📑 제목

![녹화_2021_04_15_17_03_01_816](https://user-images.githubusercontent.com/46101366/114835410-7edad980-9e0c-11eb-8885-33d0d52f511c.gif)

간단하게 색상 배정을 해주었습니다. 사용한 색상 조합은 코드에 나와 있으며 랜덤으로 시작 Index를 정한 후 순서대로 배정되는 형식입니다.
색이 16가지밖에 되지 않는다는 점과 색상 배열 순서가 비슷한 색상 순으로 이루어져 있다는 점이 유저 입장에서는 약간 단조로운 패턴으로 보일 수도 있겠다라는 생각이 듭니다. 이 부분은 추후 의논을 통해 수정하고자 합니다.
간단한 작업이니 빠르게 머지 하고자 합니다!

## 💬 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 색상 배정 기능 

## 🚧 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점
