### PR TITLE
시간표 탭 추가시 입력한 탭 이름으로 추가하도록 코드 추가

### DIFF
--- a/client/src/components/UI/molecules/TimeTableModalContent/TimeTableModalContent.tsx
+++ b/client/src/components/UI/molecules/TimeTableModalContent/TimeTableModalContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Button, DialogTitle, DialogContent, DialogActions, TextField } from '@material-ui/core';
 
 enum TimeTableModalType {
@@ -8,7 +8,7 @@ enum TimeTableModalType {
 
 interface TimeTableModalContentProps {
   modalType: TimeTableModalType;
-  onModalClose?: () => void;
+  onModalClose?: (inputValue?: string) => void;
 }
 
 const MODAL_INFO = {
@@ -24,11 +24,34 @@ const MODAL_INFO = {
 };
 
 const TimeTableModalContent = ({ modalType, onModalClose }: TimeTableModalContentProps): JSX.Element => {
+  const [timeTableTabTitle, setTimeTableTabTitle] = useState<string>();
+
   const isTabAddModal = (timeTableModalType: TimeTableModalType): boolean => timeTableModalType === TimeTableModalType.TAB_ADD_MODAL;
+
+  const onTimeTableTabTitleChangeListener = (e: React.ChangeEvent) => {
+    const target = e.target as HTMLInputElement;
+
+    setTimeTableTabTitle(target.value);
+  };
+
+  const onTimeTableModalCloseListener = () => {
+    if (onModalClose) {
+      onModalClose(timeTableTabTitle);
+    }
+  };
 
   const getTextField = (timeTableModalType: TimeTableModalType): JSX.Element | null => {
     if (isTabAddModal(timeTableModalType)) {
-      return <TextField autoFocus margin="dense" id="name" label={MODAL_INFO[TimeTableModalType.TAB_ADD_MODAL].TAB_LABEL} type="email" fullWidth />;
+      return (
+        <TextField
+          autoFocus
+          margin="dense"
+          label={MODAL_INFO[TimeTableModalType.TAB_ADD_MODAL].TAB_LABEL}
+          type="text"
+          fullWidth
+          onChange={onTimeTableTabTitleChangeListener}
+        />
+      );
     }
     return null;
   };
@@ -38,7 +61,7 @@ const TimeTableModalContent = ({ modalType, onModalClose }: TimeTableModalConten
       <DialogTitle id="form-dialog-title">{MODAL_INFO[modalType].TITLE}</DialogTitle>
       <DialogContent>{getTextField(modalType)}</DialogContent>
       <DialogActions>
-        <Button onClick={onModalClose} color="primary">
+        <Button onClick={onTimeTableModalCloseListener} color="primary">
           {MODAL_INFO[modalType].SUBMIT_BTN_NAME}
         </Button>
       </DialogActions>

--- a/client/src/components/UI/organisms/ModalPopup/ModalPopup.tsx
+++ b/client/src/components/UI/organisms/ModalPopup/ModalPopup.tsx
@@ -21,8 +21,8 @@ const ModalPopup = (): JSX.Element => {
     modalStore.setModalState(false);
   };
 
-  const onTabAddModalBtnClickListener = () => {
-    timeTableStore.addTable('시간표');
+  const onTabAddModalBtnClickListener = (timeTableTabTitle?: string) => {
+    timeTableStore.addTable(timeTableTabTitle as string);
     modalStore.setModalState(false);
   };
 

--- a/client/src/components/UI/organisms/ModalPopup/TimeTableModalPopup.tsx
+++ b/client/src/components/UI/organisms/ModalPopup/TimeTableModalPopup.tsx
@@ -5,7 +5,7 @@ interface TimeTableModalPopupProps {
   modalOpen: boolean;
   modalType: TimeTableModalType;
   onModalAreaClose: () => void;
-  onModalBtnClick: () => void;
+  onModalBtnClick: (inputValue?: string) => void;
 }
 
 const TimeTableModalPopup = ({ modalOpen, modalType, onModalAreaClose, onModalBtnClick }: TimeTableModalPopupProps): JSX.Element => {


### PR DESCRIPTION


## 📑 제목

#51  시간표 탭 추가시 입력한 탭 이름으로 추가하도록 코드 추가


## 💬 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] TimeTableModalContent에서 TextField 변화에 대한 state를 유지해서
  리스너로 전달해주는 방식으로 구현

## 🚧 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 현재 TimeTableModalContent 컴포넌트의 TextField 변화에 대해 state를 유지해서 상위 컴포넌트에게 리스너로 전달하는 방식을 사용했습니다. 헌데 TimeTableModalContent를 최초에 TabAddModal, TabRemoveModal로  isTabAddModal props에 따라 분기처리하여 상황에 따라 TextField를 끼워넣는 식으로 설계를 했습니다. 문제는 TabRemoveModal의 경우 TextField 관련 코드(state값 처리)가 불필요해서 비효율적인 구조라는 생각이 듭니다! 허나 코드가 간단해서 아직 구조를 유지중인데 어찌 생각하시나요!

- 두번째 문제는 TimeTableModalContent에서 state를 관리하니 TextField 컴포넌트의 input 값이 변할 때마다 렌더링이 발생합니다! 이는 로그인 및 회원가입 모달에서도 동일하게 나타나는데 상태가 있는 TextField를 별도의 컴포넌트로 정의해서 atom으로 분리할까 고민중입니다! 진혁님 의견이 궁금하네용 ㅎㅎ