### PR TITLE
LectureReview View 작업

### DIFF
--- a/client/src/components/UI/atoms/HashTag/HashTag.stories.tsx
+++ b/client/src/components/UI/atoms/HashTag/HashTag.stories.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import { withStoryBox } from '@/components/HOC';
+import { HashTag, HashTagProps } from './HashTag';
+
+export default {
+  title: 'atom/HashTag',
+  component: HashTag,
+  decorators: [withKnobs],
+} as Meta;
+
+const Template: Story<HashTagProps> = (args) => {
+  const HashTagStory = withStoryBox(args, 80)(HashTag);
+  return <HashTagStory {...args} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  children: '테스트',
+};

--- a/client/src/components/UI/atoms/HashTag/HashTag.tsx
+++ b/client/src/components/UI/atoms/HashTag/HashTag.tsx
@@ -31,3 +31,4 @@ const HashTag = ({ children }: HashTagProps): JSX.Element => {
 };
 
 export { HashTag };
+export type { HashTagProps };

--- a/client/src/components/UI/atoms/HashTag/HashTag.tsx
+++ b/client/src/components/UI/atoms/HashTag/HashTag.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+
+interface HashTagProps {
+  children: React.ReactChild;
+}
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    border: `1px solid ${theme.palette.primary.main}`,
+    borderRadius: '1rem',
+    padding: '0rem 0.5rem',
+    marginRight: '0.5rem',
+    backgroundColor: 'white',
+  },
+}));
+
+const HashTag = ({ children }: HashTagProps): JSX.Element => {
+  const classes = useStyles();
+  return (
+    <div className={classes.root}>
+      <Typography variant="caption" color="primary">
+        {`# ${children}`}
+      </Typography>
+    </div>
+  );
+};
+
+export { HashTag };

--- a/client/src/components/UI/atoms/LectureReviewRating/LectureReviewRating.stories.tsx
+++ b/client/src/components/UI/atoms/LectureReviewRating/LectureReviewRating.stories.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import { LectureReviewRating, LectureReviewRatingProps } from './LectureReviewRating';
+
+export default {
+  title: 'atom/LectureReviewRating',
+  component: LectureReviewRating,
+  decorators: [withKnobs],
+} as Meta;
+
+const Template: Story<LectureReviewRatingProps> = (args) => <LectureReviewRating {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  rating: 3.5,
+};

--- a/client/src/components/UI/atoms/LectureReviewRating/LectureReviewRating.tsx
+++ b/client/src/components/UI/atoms/LectureReviewRating/LectureReviewRating.tsx
@@ -32,3 +32,4 @@ const LectureReviewRating = ({ rating }: LectureReviewRatingProps): JSX.Element 
 };
 
 export { LectureReviewRating };
+export type { LectureReviewRatingProps };

--- a/client/src/components/UI/atoms/LectureReviewRating/LectureReviewRating.tsx
+++ b/client/src/components/UI/atoms/LectureReviewRating/LectureReviewRating.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Star from '@material-ui/icons/Star';
+import StarBorder from '@material-ui/icons/StarBorder';
+import StarHalf from '@material-ui/icons/StarHalf';
+
+interface LectureReviewRatingProps {
+  rating: number;
+}
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: 'flex',
+    marginLeft: '0.5rem',
+  },
+}));
+
+const LectureReviewRating = ({ rating }: LectureReviewRatingProps): JSX.Element => {
+  const classes = useStyles();
+  const getStars = () => {
+    const array = [];
+    const Stars = Math.floor(rating);
+    const isHalfStar = !!(rating - Stars);
+    const borderStars = isHalfStar ? 4 - Stars : 5 - Stars;
+    for (let i = 0; i < Stars; i++) array.push(<Star color="primary" />);
+    if (isHalfStar) array.push(<StarHalf color="primary" />);
+    for (let i = 0; i < borderStars; i++) array.push(<StarBorder color="primary" />);
+    return array;
+  };
+
+  return <div className={classes.root}>{getStars()}</div>;
+};
+
+export { LectureReviewRating };

--- a/client/src/components/UI/atoms/LectureReviewRating/LectureReviewRating.tsx
+++ b/client/src/components/UI/atoms/LectureReviewRating/LectureReviewRating.tsx
@@ -22,9 +22,9 @@ const LectureReviewRating = ({ rating }: LectureReviewRatingProps): JSX.Element 
     const Stars = Math.floor(rating);
     const isHalfStar = !!(rating - Stars);
     const borderStars = isHalfStar ? 4 - Stars : 5 - Stars;
-    for (let i = 0; i < Stars; i++) array.push(<Star color="primary" />);
-    if (isHalfStar) array.push(<StarHalf color="primary" />);
-    for (let i = 0; i < borderStars; i++) array.push(<StarBorder color="primary" />);
+    for (let i = 0; i < Stars; i++) array.push(<Star fontSize="small" color="primary" />);
+    if (isHalfStar) array.push(<StarHalf fontSize="small" color="primary" />);
+    for (let i = 0; i < borderStars; i++) array.push(<StarBorder fontSize="small" color="primary" />);
     return array;
   };
 

--- a/client/src/components/UI/atoms/ThumbScore/ThumbScore.stories.tsx
+++ b/client/src/components/UI/atoms/ThumbScore/ThumbScore.stories.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import { Thumb, ThumbProps } from './ThumbScore';
+
+export default {
+  title: 'atom/Thumb',
+  component: Thumb,
+  decorators: [withKnobs],
+} as Meta;
+
+const Template: Story<ThumbProps> = (args) => <Thumb {...args} />;
+
+export const Up = Template.bind({});
+Up.args = {
+  score: 10,
+};
+
+export const Down = Template.bind({});
+Down.args = {
+  thumbDown: true,
+  score: 10,
+};

--- a/client/src/components/UI/atoms/ThumbScore/ThumbScore.tsx
+++ b/client/src/components/UI/atoms/ThumbScore/ThumbScore.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Typography } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
-import ThumbUp from '@material-ui/icons/ThumbUp';
-import ThumbDown from '@material-ui/icons/ThumbDown';
+import ThumbUp from '@material-ui/icons/ThumbUpTwoTone';
+import ThumbDown from '@material-ui/icons/ThumbDownTwoTone';
 
 interface ThumbProps {
   thumbDown?: boolean;

--- a/client/src/components/UI/atoms/ThumbScore/ThumbScore.tsx
+++ b/client/src/components/UI/atoms/ThumbScore/ThumbScore.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import ThumbUp from '@material-ui/icons/ThumbUp';
+import ThumbDown from '@material-ui/icons/ThumbDown';
+
+interface ThumbProps {
+  thumbDown?: boolean;
+  score: number;
+  onClick?: () => void;
+}
+
+interface CSSProps {
+  thumbDown?: boolean;
+}
+
+const useStyles = makeStyles((theme) => ({
+  root: ({ thumbDown }: CSSProps) => ({
+    display: 'flex',
+    borderRadius: '1rem',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: '0.2rem',
+    '&:hover': {
+      backgroundColor: thumbDown ? '#FFD8D8' : '#D9E5FF',
+      cursor: 'pointer',
+    },
+  }),
+  down: {
+    color: '#F15F5F',
+    marginRight: '0.2rem',
+  },
+  up: {
+    color: '#6799FF',
+    marginRight: '0.2rem',
+  },
+}));
+
+const Thumb = ({ thumbDown = false, score, onClick }: ThumbProps): JSX.Element => {
+  const classes = useStyles({ thumbDown });
+  return (
+    <div className={classes.root} onClick={onClick}>
+      {thumbDown ? <ThumbDown fontSize="small" className={classes.down} /> : <ThumbUp fontSize="small" className={classes.up} />}
+      <Typography>{score}</Typography>
+    </div>
+  );
+};
+
+export { Thumb };

--- a/client/src/components/UI/atoms/ThumbScore/ThumbScore.tsx
+++ b/client/src/components/UI/atoms/ThumbScore/ThumbScore.tsx
@@ -47,3 +47,4 @@ const Thumb = ({ thumbDown = false, score, onClick }: ThumbProps): JSX.Element =
 };
 
 export { Thumb };
+export type { ThumbProps };

--- a/client/src/components/UI/atoms/index.ts
+++ b/client/src/components/UI/atoms/index.ts
@@ -12,5 +12,5 @@ export { TimeSelectMenu } from './TimeSelectMenu/TimeSelectMenu';
 export type { TimeSelectMenuProps } from './TimeSelectMenu/TimeSelectMenu';
 export { SameLectureBox } from './SameLectureBox/SameLectureBox';
 export { LectureReviewRating } from './LectureReviewRating/LectureReviewRating';
-export { Thumb } from './Thumb/Thumb';
+export { Thumb } from './ThumbScore/ThumbScore';
 export { HashTag } from './HashTag/HashTag';

--- a/client/src/components/UI/atoms/index.ts
+++ b/client/src/components/UI/atoms/index.ts
@@ -11,3 +11,4 @@ export type { SelectMenuProps } from './SelectMenu/SelectMenu';
 export { TimeSelectMenu } from './TimeSelectMenu/TimeSelectMenu';
 export type { TimeSelectMenuProps } from './TimeSelectMenu/TimeSelectMenu';
 export { SameLectureBox } from './SameLectureBox/SameLectureBox';
+export { LectureReviewRating } from './LectureReviewRating/LectureReviewRating';

--- a/client/src/components/UI/atoms/index.ts
+++ b/client/src/components/UI/atoms/index.ts
@@ -12,3 +12,5 @@ export { TimeSelectMenu } from './TimeSelectMenu/TimeSelectMenu';
 export type { TimeSelectMenuProps } from './TimeSelectMenu/TimeSelectMenu';
 export { SameLectureBox } from './SameLectureBox/SameLectureBox';
 export { LectureReviewRating } from './LectureReviewRating/LectureReviewRating';
+export { Thumb } from './Thumb/Thumb';
+export { HashTag } from './HashTag/HashTag';

--- a/client/src/components/UI/molecules/LectureReviewHashTags/LectureReviewHashTags.stories.tsx
+++ b/client/src/components/UI/molecules/LectureReviewHashTags/LectureReviewHashTags.stories.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import { withStoryBox } from '@/components/HOC';
+import { LectureReviewHashTags, LectureReviewHashTagsProps } from './LectureReviewHashTags';
+
+export default {
+  title: 'molecules/LectureReviewHashTags',
+  component: LectureReviewHashTags,
+  decorators: [withKnobs],
+} as Meta;
+
+const Template: Story<LectureReviewHashTagsProps> = (args) => {
+  const LectureReviewHashTagsStory = withStoryBox(args, 250)(LectureReviewHashTags);
+  return <LectureReviewHashTagsStory {...args} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  tags: ['테스트', '스토리북', '진혀쿠'],
+};

--- a/client/src/components/UI/molecules/LectureReviewHashTags/LectureReviewHashTags.tsx
+++ b/client/src/components/UI/molecules/LectureReviewHashTags/LectureReviewHashTags.tsx
@@ -23,3 +23,4 @@ const LectureReviewHashTags = ({ tags }: LectureReviewHashTagsProps): JSX.Elemen
 };
 
 export { LectureReviewHashTags };
+export type { LectureReviewHashTagsProps };

--- a/client/src/components/UI/molecules/LectureReviewHashTags/LectureReviewHashTags.tsx
+++ b/client/src/components/UI/molecules/LectureReviewHashTags/LectureReviewHashTags.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { HashTag } from '@/components/UI/atoms';
+import { makeStyles } from '@material-ui/core/styles';
+
+interface LectureReviewHashTagsProps {
+  tags: string[];
+}
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: 'flex',
+  },
+}));
+
+const LectureReviewHashTags = ({ tags }: LectureReviewHashTagsProps): JSX.Element => {
+  const classes = useStyles();
+  const getHashTags = () => {
+    return tags.map((tag) => {
+      return <HashTag key={tag}>{tag}</HashTag>;
+    });
+  };
+  return <div className={classes.root}>{getHashTags()}</div>;
+};
+
+export { LectureReviewHashTags };

--- a/client/src/components/UI/molecules/LectureReviewInfo/LectureReviewInfo.stories.tsx
+++ b/client/src/components/UI/molecules/LectureReviewInfo/LectureReviewInfo.stories.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import { withStoryBox } from '@/components/HOC';
+import { LectureReviewInfo, LectureReviewInfoProps } from './LectureReviewInfo';
+
+export default {
+  title: 'molecules/LectureReviewInfo',
+  component: LectureReviewInfo,
+  decorators: [withKnobs],
+} as Meta;
+
+const Template: Story<LectureReviewInfoProps> = (args) => {
+  const LectureReviewInfoStory = withStoryBox(args, 500)(LectureReviewInfo);
+  return <LectureReviewInfoStory {...args} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  lectureName: '스토리북테스트',
+  profName: '진혀쿠님',
+  rating: 5,
+  period: '2021년도 1학기',
+};

--- a/client/src/components/UI/molecules/LectureReviewInfo/LectureReviewInfo.tsx
+++ b/client/src/components/UI/molecules/LectureReviewInfo/LectureReviewInfo.tsx
@@ -43,3 +43,4 @@ const LectureReviewInfo = ({ lectureName, profName, rating, period }: LectureRev
 };
 
 export { LectureReviewInfo };
+export type { LectureReviewInfoProps };

--- a/client/src/components/UI/molecules/LectureReviewInfo/LectureReviewInfo.tsx
+++ b/client/src/components/UI/molecules/LectureReviewInfo/LectureReviewInfo.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import { LectureReviewRating } from '@/components/UI/atoms';
+
+interface LectureReviewInfoProps {
+  lectureName: string;
+  profName: string;
+  rating: number;
+  period: string;
+}
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  item: {
+    marginLeft: '0.5rem',
+  },
+}));
+
+const LectureReviewInfo = ({ lectureName, profName, rating, period }: LectureReviewInfoProps): JSX.Element => {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.root}>
+      <Typography variant="subtitle1">{lectureName}</Typography>
+      <Typography className={classes.item} variant="subtitle2">
+        {profName}
+      </Typography>
+      <LectureReviewRating rating={rating} />
+      <Typography className={classes.item} variant="overline">
+        {period}
+      </Typography>
+    </div>
+  );
+};
+
+export { LectureReviewInfo };

--- a/client/src/components/UI/molecules/LectureReviewInfo/LectureReviewInfo.tsx
+++ b/client/src/components/UI/molecules/LectureReviewInfo/LectureReviewInfo.tsx
@@ -18,6 +18,9 @@ const useStyles = makeStyles((theme) => ({
   item: {
     marginLeft: '0.5rem',
   },
+  weight: {
+    fontWeight: 'bold',
+  },
 }));
 
 const LectureReviewInfo = ({ lectureName, profName, rating, period }: LectureReviewInfoProps): JSX.Element => {
@@ -25,7 +28,9 @@ const LectureReviewInfo = ({ lectureName, profName, rating, period }: LectureRev
 
   return (
     <div className={classes.root}>
-      <Typography variant="subtitle1">{lectureName}</Typography>
+      <Typography className={classes.weight} variant="subtitle1">
+        {lectureName}
+      </Typography>
       <Typography className={classes.item} variant="subtitle2">
         {profName}
       </Typography>

--- a/client/src/components/UI/molecules/LectureReviewThumbs/LectureReviewThumbs.stories.tsx
+++ b/client/src/components/UI/molecules/LectureReviewThumbs/LectureReviewThumbs.stories.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import { withStoryBox } from '@/components/HOC';
+import { LectureReviewThumbs, LectureReviewThumbsProps } from './LectureReviewThumbs';
+
+export default {
+  title: 'molecules/LectureReviewThumbs',
+  component: LectureReviewThumbs,
+  decorators: [withKnobs],
+} as Meta;
+
+const Template: Story<LectureReviewThumbsProps> = (args) => {
+  const LectureReviewThumbsStory = withStoryBox(args, 250)(LectureReviewThumbs);
+  return <LectureReviewThumbsStory {...args} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  upScore: 20,
+  downScore: 10,
+};

--- a/client/src/components/UI/molecules/LectureReviewThumbs/LectureReviewThumbs.tsx
+++ b/client/src/components/UI/molecules/LectureReviewThumbs/LectureReviewThumbs.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import { Thumb } from '@/components/UI/atoms';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: 'flex',
+  },
+}));
+
+const LectureReviewThumbs = (): JSX.Element => {
+  const classes = useStyles();
+  return (
+    <div className={classes.root}>
+      <Thumb />
+      <Thumb thumbDown />
+    </div>
+  );
+};
+
+export { LectureReviewThumbs };

--- a/client/src/components/UI/molecules/LectureReviewThumbs/LectureReviewThumbs.tsx
+++ b/client/src/components/UI/molecules/LectureReviewThumbs/LectureReviewThumbs.tsx
@@ -2,20 +2,26 @@ import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { Thumb } from '@/components/UI/atoms';
 
+interface LectureReviewThumbsProps {
+  upScore: number;
+  downScore: number;
+}
+
 const useStyles = makeStyles((theme) => ({
   root: {
     display: 'flex',
   },
 }));
 
-const LectureReviewThumbs = (): JSX.Element => {
+const LectureReviewThumbs = ({ upScore, downScore }: LectureReviewThumbsProps): JSX.Element => {
   const classes = useStyles();
   return (
     <div className={classes.root}>
-      <Thumb />
-      <Thumb thumbDown />
+      <Thumb score={upScore} />
+      <Thumb score={downScore} thumbDown />
     </div>
   );
 };
 
 export { LectureReviewThumbs };
+export type { LectureReviewThumbsProps };

--- a/client/src/components/UI/molecules/index.ts
+++ b/client/src/components/UI/molecules/index.ts
@@ -23,3 +23,4 @@ export { TimeTableAddForm } from './TimeTableAddForm/TimeTableAddForm';
 export { SignUpModalContent, SignUpModalType } from './SignUpModalContent/SignUpModalContent';
 export { LectureReviewInfo } from './LectureReviewInfo/LectureReviewInfo';
 export { LectureReviewThumbs } from './LectureReviewThumbs/LectureReviewThumbs';
+export { LectureReviewHashTags } from './LectureReviewHashTags/LectureReviewHashTags';

--- a/client/src/components/UI/molecules/index.ts
+++ b/client/src/components/UI/molecules/index.ts
@@ -22,5 +22,7 @@ export { LectureSearchFilterMenu } from './LectureSearchFilter/LectureSearchFilt
 export { TimeTableAddForm } from './TimeTableAddForm/TimeTableAddForm';
 export { SignUpModalContent, SignUpModalType } from './SignUpModalContent/SignUpModalContent';
 export { LectureReviewInfo } from './LectureReviewInfo/LectureReviewInfo';
+export type { LectureReviewInfoProps } from './LectureReviewInfo/LectureReviewInfo';
 export { LectureReviewThumbs } from './LectureReviewThumbs/LectureReviewThumbs';
+export type { LectureReviewThumbsProps } from './LectureReviewThumbs/LectureReviewThumbs';
 export { LectureReviewHashTags } from './LectureReviewHashTags/LectureReviewHashTags';

--- a/client/src/components/UI/molecules/index.ts
+++ b/client/src/components/UI/molecules/index.ts
@@ -22,3 +22,4 @@ export { LectureSearchFilterMenu } from './LectureSearchFilter/LectureSearchFilt
 export { TimeTableAddForm } from './TimeTableAddForm/TimeTableAddForm';
 export { SignUpModalContent, SignUpModalType } from './SignUpModalContent/SignUpModalContent';
 export { LectureReviewInfo } from './LectureReviewInfo/LectureReviewInfo';
+export { LectureReviewThumbs } from './LectureReviewThumbs/LectureReviewThumbs';

--- a/client/src/components/UI/molecules/index.ts
+++ b/client/src/components/UI/molecules/index.ts
@@ -21,3 +21,4 @@ export { LoginModalContent, LoginModalType } from './LoginModalContent/LoginModa
 export { LectureSearchFilterMenu } from './LectureSearchFilter/LectureSearchFilterMenu';
 export { TimeTableAddForm } from './TimeTableAddForm/TimeTableAddForm';
 export { SignUpModalContent, SignUpModalType } from './SignUpModalContent/SignUpModalContent';
+export { LectureReviewInfo } from './LectureReviewInfo/LectureReviewInfo';

--- a/client/src/components/UI/organisms/LectureReview/LectureReview.stories.tsx
+++ b/client/src/components/UI/organisms/LectureReview/LectureReview.stories.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import { withStoryBox } from '@/components/HOC';
+import { LectureReview, LectureReviewProps } from './LectureReview';
+
+export default {
+  title: 'organisms/LectureReview',
+  component: LectureReview,
+  decorators: [withKnobs],
+} as Meta;
+
+const Template: Story<LectureReviewProps> = (args) => {
+  const LectureReviewStory = withStoryBox(args, 800)(LectureReview);
+  return <LectureReviewStory {...args} />;
+};
+
+export const MyReview = Template.bind({});
+MyReview.args = {
+  infos: {
+    lectureName: '취준하며놀고먹기',
+    profName: '진혀쿠',
+    rating: 1.5,
+    period: '2021년도 1학기',
+  },
+  content: '취준하면서 놀고 먹고 싶다구요? 저처럼 공부를 안 하면 된답니다!',
+  tags: ['백수', '진혀쿠', '나처럼살지마'],
+  scores: {
+    upScore: 5,
+    downScore: 18,
+  },
+  isMine: true,
+};
+
+export const OthersReview = Template.bind({});
+OthersReview.args = {
+  infos: {
+    lectureName: '멋지게취업하기',
+    profName: '갓우진',
+    rating: 5,
+    period: '2021년도 1학기',
+  },
+  content: '나는야 갓우진 그린팩토리를 점령할 사람이지!',
+  tags: ['취뽀', '신과함께'],
+  scores: {
+    upScore: 1000,
+    downScore: 0,
+  },
+};

--- a/client/src/components/UI/organisms/LectureReview/LectureReview.tsx
+++ b/client/src/components/UI/organisms/LectureReview/LectureReview.tsx
@@ -76,3 +76,4 @@ const LectureReview = ({ infos, content, tags, scores, isMine = false }: Lecture
 };
 
 export { LectureReview };
+export type { LectureReviewProps };

--- a/client/src/components/UI/organisms/LectureReview/LectureReview.tsx
+++ b/client/src/components/UI/organisms/LectureReview/LectureReview.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import {
+  LectureReviewInfo,
+  LectureReviewThumbs,
+  LectureReviewHashTags,
+  LectureReviewInfoProps,
+  LectureReviewThumbsProps,
+} from '@/components/UI/molecules';
+
+interface LectureReviewProps {
+  infos: LectureReviewInfoProps;
+  content: string;
+  tags: string[];
+  scores: LectureReviewThumbsProps;
+  isMine?: boolean;
+}
+
+interface CSSProps {
+  isMine: boolean;
+}
+
+const useStyles = makeStyles((theme) => ({
+  root: ({ isMine }: CSSProps) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+    width: '40rem',
+    height: '9rem',
+    border: `1px solid ${isMine ? theme.palette.primary.main : theme.palette.grey[300]}`,
+    backgroundColor: isMine ? '#fdf6eb' : 'white',
+    borderRadius: '0.5rem',
+    padding: '1rem',
+    marginBottom: '1rem',
+  }),
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    height: '25%',
+  },
+  body: {
+    height: '45%',
+  },
+  content: {
+    overflow: 'hidden',
+    lineHeight: 1.2,
+    textAlign: 'left',
+    height: '3.6rem',
+    textOverFlow: 'ellipsis',
+    display: '-webkit-box',
+    '&::-webkit-line-clamp': 3,
+    '&::-webkit-box-orient': 'vertical',
+    wordWrap: 'break-word',
+    whiteSpace: 'normal',
+  },
+  bottom: {
+    height: '20%',
+  },
+}));
+
+const LectureReview = ({ infos, content, tags, scores, isMine = false }: LectureReviewProps): JSX.Element => {
+  const classes = useStyles({ isMine });
+
+  return (
+    <div className={classes.root}>
+      <div className={classes.header}>
+        <LectureReviewInfo lectureName={infos.lectureName} profName={infos.profName} rating={infos.rating} period={infos.period} />
+        <LectureReviewThumbs upScore={scores.upScore} downScore={scores.downScore} />
+      </div>
+      <div className={classes.content}>{content}</div>
+      <div className={classes.bottom}>
+        <LectureReviewHashTags tags={tags} />
+      </div>
+    </div>
+  );
+};
+
+export { LectureReview };

--- a/client/src/components/UI/organisms/LectureReview/LectureReviewContainer.tsx
+++ b/client/src/components/UI/organisms/LectureReview/LectureReviewContainer.tsx
@@ -1,0 +1,62 @@
+/* eslint-disable react/no-array-index-key */
+import React from 'react';
+import { LectureReview } from './LectureReview';
+
+const mockData = [
+  {
+    infos: {
+      lectureName: '디자인커뮤니케이션',
+      profName: '윤정식',
+      rating: 3.5,
+      period: '2020년도 2학기',
+    },
+    content:
+      'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur unde suscipit, quam beatae rerum inventore consectetur, neque doloribus, cupiditate numquam dignissimos laborum fugiat deleniti? Eum quasi quidem quibusdam. 안녕하세요 제 이름은 지녀쿠입니다. 한기대학생이 아니지만 한표를 만들고 있답니다 하하',
+    tags: ['꿀수업', '진혀쿠', '돔황챠'],
+    scores: {
+      upScore: 20,
+      downScore: 3,
+    },
+  },
+  {
+    infos: {
+      lectureName: '취준하며놀고먹기',
+      profName: '진혀쿠',
+      rating: 1.5,
+      period: '2021년도 1학기',
+    },
+    content: '취준하면서 놀고 먹고 싶다구요? 저처럼 공부를 안 하면 된답니다!',
+    tags: ['백수', '진혀쿠', '나처럼살지마'],
+    scores: {
+      upScore: 5,
+      downScore: 18,
+    },
+    isMine: true,
+  },
+  {
+    infos: {
+      lectureName: '디자인커뮤니케이션',
+      profName: '윤정식',
+      rating: 4,
+      period: '2020년도 2학기',
+    },
+    content:
+      'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur unde suscipit, quam beatae rerum inventore consectetur, neque doloribus, cupiditate numquam dignissimos laborum fugiat deleniti? Eum quasi quidem quibusdam. 안녕하세요 제 이름은 지녀쿠입니다. 한기대학생이 아니지만 한표를 만들고 있답니다 하하',
+    tags: ['꿀수업', '진혀쿠', '돔황챠'],
+    scores: {
+      upScore: 20,
+      downScore: 3,
+    },
+  },
+];
+
+const LectureReviewContainer = (): JSX.Element => {
+  const getLectureReviews = () => {
+    return mockData.map((data, idx) => {
+      return <LectureReview key={idx} infos={data.infos} content={data.content} tags={data.tags} scores={data.scores} isMine={data.isMine} />;
+    });
+  };
+  return <>{getLectureReviews()}</>;
+};
+
+export { LectureReviewContainer };

--- a/client/src/components/UI/organisms/index.ts
+++ b/client/src/components/UI/organisms/index.ts
@@ -4,3 +4,4 @@ export { LectureList } from './LectureList/LectureList';
 export type { LectureListProps } from './LectureList/LectureList';
 export { Header } from './Header/Header';
 export { TimeTableMenu } from './TimeTableMenu/TimeTableMenu';
+export { LectureReviewContainer } from './LectureReview/LectureReviewContainer';

--- a/client/src/components/pages/ReviewPage.tsx
+++ b/client/src/components/pages/ReviewPage.tsx
@@ -1,12 +1,24 @@
+/* eslint-disable react/no-array-index-key */
 import React from 'react';
-import { Header } from '@/components/UI/organisms';
+import { makeStyles } from '@material-ui/core/styles';
+import { Header, LectureReviewContainer } from '@/components/UI/organisms';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+}));
 
 const ReviewPage = (): JSX.Element => {
+  const classes = useStyles();
   return (
-    <>
+    <div className={classes.root}>
       <Header />
-      <div>강의 후기</div>
-    </>
+      <LectureReviewContainer />
+    </div>
   );
 };
 


### PR DESCRIPTION
## 📑 제목

![녹화_2021_04_21_20_11_30_402](https://user-images.githubusercontent.com/46101366/115544727-e9dd5200-a2dd-11eb-914d-6a4317c350df.gif)

LectureReview View 작업을 완료했습니다.

LectureReview 안에 많은 컴포넌트들이 들어가서 제작되다 보니 굉장히 많은 파일들이 생겼는데 너무 세분화 시켰나 하는 생각도 듭니다. 아직 비즈니스 로직 작성이 되지 않아서 구조가 제대로 잡히지 않았는데 로직 작성될 때 구조를 잘 분리해보겠습니다!

LectureReview를 organism으로 보는게 맞나 모르겠습니다. atomic design 분류하기가 조금 애매한 컴포넌트네요!

## 💬 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 상단 이미지와 같습니다.


## 🚧 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- Thumb라는 이름을 git이 추적을 못하더라구요..! 그래서 파일명은 ThumbScore로 해놓고 export 할 때는 Thumb라는 이름으로 export 시켰습니다. 혹시 모르니 참고해주세요!