### PR TITLE
전체 코드 리팩토링

### DIFF
--- a/client/src/common/utils/debounce.ts
+++ b/client/src/common/utils/debounce.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-this-alias */
 const debounce = (func: Function, wait: number): (() => void) => {
   let timeout: NodeJS.Timeout | null;

--- a/client/src/components/UI/atoms/AlertSnackbar/AlertSnackbar.tsx
+++ b/client/src/components/UI/atoms/AlertSnackbar/AlertSnackbar.tsx
@@ -19,7 +19,8 @@ const AlertSnackbar = (): JSX.Element => {
   const { snackbarStore } = useStores();
   const snackbarState = useReactiveVar(snackbarStore.state.snackbarState);
   const snackbarType = useReactiveVar(snackbarStore.state.snackbarType);
-  const onCloseHandler = (event: React.SyntheticEvent | React.MouseEvent, reason?: string) => {
+
+  const onSnackbarCloseListener = (event: React.SyntheticEvent | React.MouseEvent, reason?: string) => {
     if (reason === 'clickaway') {
       return;
     }
@@ -36,10 +37,10 @@ const AlertSnackbar = (): JSX.Element => {
         }}
         open={snackbarState}
         autoHideDuration={1500}
-        onClose={onCloseHandler}
+        onClose={onSnackbarCloseListener}
         message={SNACKBAR_MESSAGE[snackbarType]}
         action={
-          <IconButton size="small" aria-label="close" color="inherit" onClick={onCloseHandler}>
+          <IconButton size="small" aria-label="close" color="inherit" onClick={onSnackbarCloseListener}>
             <CloseIcon fontSize="small" />
           </IconButton>
         }

--- a/client/src/components/UI/atoms/LectureBox/LectureBox.tsx
+++ b/client/src/components/UI/atoms/LectureBox/LectureBox.tsx
@@ -9,9 +9,9 @@ interface LectureBoxProps {
   startTime: number;
   endTime: number;
   bgcolor?: string;
-  name: string;
-  division?: string;
-  prof: string;
+  lectureName: string;
+  classNumber?: string;
+  professorName: string;
 }
 
 interface CSSProps {
@@ -22,27 +22,31 @@ interface CSSProps {
 }
 
 const useStyles = makeStyles((theme) => ({
-  root: {
+  root: ({ rowStartPos, rowEndPos, columnPos, bgcolor }: CSSProps) => ({
     display: 'flex',
     flexDirection: 'column',
     position: 'absolute',
-    height: (props: CSSProps) => (props.rowStartPos * 2 + props.rowEndPos * 2 <= 40 ? `${props.rowEndPos * 2}rem` : '4rem'),
+    height: rowStartPos * 2 + rowEndPos * 2 <= 40 ? `${rowEndPos * 2}rem` : '4rem',
     width: '5rem',
-    left: (props: CSSProps) => `${5 + props.columnPos * 5}rem`,
-    top: (props: CSSProps) => (props.rowStartPos * 2 + props.rowEndPos * 2 <= 40 ? `${4 + props.rowStartPos * 2}rem` : '40rem'),
+    left: `${5 + columnPos * 5}rem`,
+    top: rowStartPos * 2 + rowEndPos * 2 <= 40 ? `${4 + rowStartPos * 2}rem` : '40rem',
     boxSizing: 'border-box',
-    backgroundColor: (props: CSSProps) => props.bgcolor || 'rgba(250, 244, 192)',
+    backgroundColor: bgcolor || 'rgba(250, 244, 192)',
     border: `1px solid ${theme.palette.grey[300]}`,
     borderTop: `2px solid ${theme.palette.grey[300]}`,
+
     '&:hover': {
       boxShadow: '0 3px 4.5px 0 rgba(0, 0, 0, 0.16)',
-      '& > div[class*="makeStyles-membrane"]': {
+
+      '&:first-child': {
         display: 'block',
       },
+
       '& .MuiButtonBase-root': {
         display: 'block',
       },
     },
+
     '& .MuiButtonBase-root': {
       display: 'none',
       position: 'absolute',
@@ -50,7 +54,7 @@ const useStyles = makeStyles((theme) => ({
       top: '50%',
       left: '50%',
     },
-  },
+  }),
   membrane: {
     display: 'none',
     position: 'absolute',
@@ -61,14 +65,17 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const LectureBox = ({ startTime, endTime, bgcolor, name, division, prof }: LectureBoxProps): JSX.Element => {
+const LectureBox = ({ startTime, endTime, bgcolor, lectureName, classNumber, professorName }: LectureBoxProps): JSX.Element => {
   const columnPos = Math.floor(startTime / 1440);
   const rowStartPos = ((startTime % 1440) - 540) / 30;
   const rowEndPos = (endTime - startTime) / 30;
   const classes = useStyles({ columnPos, rowStartPos, rowEndPos, bgcolor });
+
   const { timeTableStore, snackbarStore } = useStores();
-  const onClickHandler = () => {
-    timeTableStore.removeLectureFromTable(name);
+
+  const onLectureBoxClickListener = () => {
+    timeTableStore.removeLectureFromTable(lectureName);
+
     snackbarStore.setSnackbarType(SnackbarType.DELETE_SUCCESS);
     snackbarStore.setSnackbarState(true);
   };
@@ -76,16 +83,16 @@ const LectureBox = ({ startTime, endTime, bgcolor, name, division, prof }: Lectu
   return (
     <div className={classes.root}>
       <div className={classes.membrane} />
-      <Tooltip title="시간표 삭제" arrow placement="right" onClick={() => onClickHandler()}>
+      <Tooltip title="시간표 삭제" arrow placement="right" onClick={onLectureBoxClickListener}>
         <IconButton aria-label="delete">
           <DeleteIcon style={{ fontSize: 16 }} />
         </IconButton>
       </Tooltip>
       <div>
-        <Typography variant="subtitle2">{name}</Typography>
+        <Typography variant="subtitle2">{lectureName}</Typography>
       </div>
       <div>
-        <Typography variant="caption">{`${division || '01'} ${prof}`}</Typography>
+        <Typography variant="caption">{`${classNumber || '01'} ${professorName}`}</Typography>
       </div>
     </div>
   );

--- a/client/src/components/UI/atoms/LectureInfoTitle/LectureInfoTitle.tsx
+++ b/client/src/components/UI/atoms/LectureInfoTitle/LectureInfoTitle.tsx
@@ -15,7 +15,7 @@ enum LectureInfoTitleType {
 
 interface TitleProps {
   className: LectureInfoTitleType;
-  children: any;
+  children: JSX.Element[] | string;
   isHeader: boolean;
 }
 

--- a/client/src/components/UI/atoms/SameLectureBox/SameLectureBox.tsx
+++ b/client/src/components/UI/atoms/SameLectureBox/SameLectureBox.tsx
@@ -4,18 +4,18 @@ import { makeStyles } from '@material-ui/core/styles';
 interface SameLectureBoxProps {
   startTime: number;
   endTime: number;
-  nowSelected?: boolean;
+  isSelectedLecture?: boolean;
 }
 
 interface CSSProps {
   columnPos: number;
   rowStartPos: number;
   rowEndPos: number;
-  nowSelected?: boolean;
+  isSelectedLecture?: boolean;
 }
 
 const useStyles = makeStyles((theme) => ({
-  root: ({ columnPos, rowStartPos, rowEndPos, nowSelected }: CSSProps) => ({
+  root: ({ columnPos, rowStartPos, rowEndPos, isSelectedLecture }: CSSProps) => ({
     display: 'flex',
     flexDirection: 'column',
     position: 'absolute',
@@ -24,15 +24,15 @@ const useStyles = makeStyles((theme) => ({
     boxSizing: 'border-box',
     left: `${5 + columnPos * 5}rem`,
     top: rowStartPos * 2 + rowEndPos * 2 <= 40 ? `${4 + rowStartPos * 2}rem` : '40rem',
-    border: `${nowSelected ? 4 : 2}px solid ${theme.palette.primary.main}`,
+    border: `${isSelectedLecture ? 4 : 2}px solid ${theme.palette.primary.main}`,
   }),
 }));
 
-const SameLectureBox = ({ startTime, endTime, nowSelected }: SameLectureBoxProps): JSX.Element => {
+const SameLectureBox = ({ startTime, endTime, isSelectedLecture }: SameLectureBoxProps): JSX.Element => {
   const columnPos = Math.floor(startTime / 1440);
   const rowStartPos = ((startTime % 1440) - 540) / 30;
   const rowEndPos = (endTime - startTime) / 30;
-  const classes = useStyles({ columnPos, rowStartPos, rowEndPos, nowSelected });
+  const classes = useStyles({ columnPos, rowStartPos, rowEndPos, isSelectedLecture });
 
   return <div className={classes.root} />;
 };

--- a/client/src/components/UI/molecules/HeaderAuthSection/HeaderAuthSectionArea.tsx
+++ b/client/src/components/UI/molecules/HeaderAuthSection/HeaderAuthSectionArea.tsx
@@ -37,6 +37,7 @@ const useStyles = makeStyles((theme) => ({
 
 const HeaderAuthSectionArea = ({ onLoginClick, onSignUpClick }: HeaderAuthSectionAreaProps): JSX.Element => {
   const classes = useStyles();
+
   return (
     <div className={classes.loginSection}>
       <Typography className={classes.promotionText} variant="caption">

--- a/client/src/components/UI/molecules/LectureBoxContainer/LectureBoxContainer.tsx
+++ b/client/src/components/UI/molecules/LectureBoxContainer/LectureBoxContainer.tsx
@@ -4,7 +4,7 @@ import { LectureBox, SameLectureBox } from '@/components/UI/atoms';
 import { useStores } from '@/stores';
 import { useReactiveVar } from '@apollo/client';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles({
   root: {
     position: 'absolute',
     top: 0,
@@ -12,7 +12,7 @@ const useStyles = makeStyles((theme) => ({
     width: '100%',
     height: '100%',
   },
-}));
+});
 
 const LectureBoxContainer = (): JSX.Element => {
   const classes = useStyles();
@@ -21,32 +21,49 @@ const LectureBoxContainer = (): JSX.Element => {
   const selectedTabIdx = useReactiveVar(timeTableStore.state.selectedTabIdx);
   const nowSelectedLecture = useReactiveVar(lectureInfoStore.state.selectedLecture);
 
-  const fillTableByLectures = () => {
+  const getLectureBoxes = () => {
     if (selectedTabIdx === 0) return <></>;
+
     const lectureInfos = savedLectures[selectedTabIdx - 1];
     if (!lectureInfos) return <></>;
-    return lectureInfos.map((elem) => {
-      if (typeof elem.time === 'string') return <></>;
-      return elem.time.map((time) => {
-        return <LectureBox startTime={time.start} endTime={time.end} name={elem.name} division={elem.class} prof={elem.prof} bgcolor={elem.color} />;
+
+    return lectureInfos.map((lectureInfo) => {
+      if (typeof lectureInfo.time === 'string') return <></>;
+
+      return lectureInfo.time.map((time) => {
+        return (
+          <LectureBox
+            startTime={time.start}
+            endTime={time.end}
+            lectureName={lectureInfo.name}
+            classNumber={lectureInfo.class}
+            professorName={lectureInfo.prof}
+            bgcolor={lectureInfo.color}
+          />
+        );
       });
     });
   };
 
-  const showSameLectures = () => {
+  const getSameLectureBoxes = () => {
     const sameLectures = lectureInfoStore.getSameLectures();
+
     return sameLectures.map((sameLecture) => {
       if (typeof sameLecture.time === 'string') return <></>;
+
       return sameLecture.time.map((time) => {
-        if (sameLecture.class === nowSelectedLecture?.class) return <SameLectureBox startTime={time.start} endTime={time.end} nowSelected />;
+        if (sameLecture.class === nowSelectedLecture?.class) {
+          return <SameLectureBox startTime={time.start} endTime={time.end} isSelectedLecture />;
+        }
         return <SameLectureBox startTime={time.start} endTime={time.end} />;
       });
     });
   };
+
   return (
     <div className={classes.root}>
-      {fillTableByLectures()}
-      {showSameLectures()}
+      {getLectureBoxes()}
+      {getSameLectureBoxes()}
     </div>
   );
 };

--- a/client/src/components/UI/molecules/LectureInfo/LectureInfo.tsx
+++ b/client/src/components/UI/molecules/LectureInfo/LectureInfo.tsx
@@ -66,41 +66,64 @@ interface LectureInfoProps {
   isBasketList?: boolean;
 }
 
+const LECTURE_INFO_TOOLTIP_MESSAGE = {
+  REMOVE_MESSAGE: '시간표에서 제거하기',
+  ADD_MESSAGE: '시간표에 추가하기',
+};
+
 const LectureInfo = ({ isHeader = false, infos, onDoubleClick, onClick, isBasketList = false }: LectureInfoProps): JSX.Element => {
   const classes = useStyles();
   const subClass = isHeader ? classes.header : classes.item;
+
   const { lectureInfoStore } = useStores();
+
   const nowSelectedLectureInfo = isBasketList
     ? useReactiveVar(lectureInfoStore.state.basketSelectedLecture)
     : useReactiveVar(lectureInfoStore.state.selectedLecture);
-  const isSelectedLecture = () => {
+
+  const checkSelectedLecture = (): boolean => {
     return nowSelectedLectureInfo?.code === infos.code && nowSelectedLectureInfo?.class === infos.class;
   };
-  const convertNumberToTime = (time: number) => {
+
+  const convertNumberToTime = (time: number): string => {
     const hour = Math.floor((time % 1440) / 60)
       .toString()
       .padStart(2, '0');
     const minute = (time % 60).toString().padEnd(2, '0');
+
     return `${hour}:${minute}`;
   };
-  const convertTimeToString = (times: TimeTypes) => {
+
+  const convertTimeToString = (times: TimeTypes): string => {
     const days = ['월', '화', '수', '목', '금', '토'];
     const startDay = days[Math.floor(times.start / 1440)];
     const startTime = convertNumberToTime(times.start);
     const endTime = convertNumberToTime(times.end);
+
     return `${startDay} ${startTime} - ${endTime}`;
   };
-  const getLectureTime = (times: Array<TimeTypes> | string) => {
+
+  const getLectureTimes = (times: Array<TimeTypes> | string): JSX.Element[] | string => {
     if (typeof times === 'string') return times;
+
     return times.map((time) => {
-      return <Typography variant="caption">{convertTimeToString(time)}</Typography>;
+      return (
+        <Typography key={time.start} variant="caption">
+          {convertTimeToString(time)}
+        </Typography>
+      );
     });
   };
+
   return (
-    <Tooltip title={isBasketList ? '시간표에서 제거하기' : '시간표에 추가하기'} placement="left" arrow disableHoverListener={isHeader}>
+    <Tooltip
+      title={isBasketList ? LECTURE_INFO_TOOLTIP_MESSAGE.REMOVE_MESSAGE : LECTURE_INFO_TOOLTIP_MESSAGE.ADD_MESSAGE}
+      placement="left"
+      arrow
+      disableHoverListener={isHeader}>
       <div
         className={`${classes.root} ${subClass}`}
-        data-selected={isSelectedLecture()}
+        data-selected={checkSelectedLecture()}
         onClick={() => onClick(infos)}
         onDoubleClick={() => onDoubleClick(infos)}>
         <LectureInfoTitle className={LectureInfoTitleType.code} isHeader={isHeader}>
@@ -132,7 +155,7 @@ const LectureInfo = ({ isHeader = false, infos, onDoubleClick, onClick, isBasket
         </LectureInfoTitle>
         <LectureInfoDivider />
         <LectureInfoTitle className={LectureInfoTitleType.time} isHeader={isHeader}>
-          {getLectureTime(infos.time)}
+          {getLectureTimes(infos.time)}
         </LectureInfoTitle>
       </div>
     </Tooltip>

--- a/client/src/components/UI/molecules/LectureListBody/SearchedLectureListBody.tsx
+++ b/client/src/components/UI/molecules/LectureListBody/SearchedLectureListBody.tsx
@@ -5,7 +5,7 @@ import { useStores } from '@/stores';
 
 interface SearchedLectureListBodyProps {
   isBasketList?: boolean;
-  getLectureInfos: (infos: Array<LectureInfos>) => any;
+  getLectureInfos: (infos: Array<LectureInfos>) => JSX.Element[];
 }
 
 const useStyles = makeStyles((theme) => ({

--- a/client/src/components/UI/organisms/LectureList/LectureList.tsx
+++ b/client/src/components/UI/organisms/LectureList/LectureList.tsx
@@ -46,35 +46,44 @@ const headerInfos = {
 
 const LectureList = ({ isBasketList = false }: LectureListProps): JSX.Element => {
   const classes = useStyles({ isBasketList });
-
   const { timeTableStore, snackbarStore, lectureInfoStore } = useStores();
+
   const onLectureSearchDoubleClickListener = (lectureInfos: LectureInfos) => {
     if (typeof lectureInfos.time === 'string') return;
+
     timeTableStore.addLectureToTable(lectureInfos);
     snackbarStore.setSnackbarType(SnackbarType.ADD_SUCCESS);
     snackbarStore.setSnackbarState(true);
   };
+
   const onBasketLectureDoubleClickListener = (lectureInfos: LectureInfos) => {
     if (typeof lectureInfos.time === 'string') return;
+
     timeTableStore.removeLectureFromTable(lectureInfos.name);
     snackbarStore.setSnackbarType(SnackbarType.DELETE_SUCCESS);
     snackbarStore.setSnackbarState(true);
   };
+
   const onLectureSearchClickListener = (lectureInfos: LectureInfos) => {
     if (typeof lectureInfos.time === 'string') return;
+
     lectureInfoStore.state.selectedLecture(lectureInfos);
   };
+
   const onBasketLectureClickListener = (lectureInfos: LectureInfos) => {
     if (typeof lectureInfos.time === 'string') return;
+
     lectureInfoStore.state.basketSelectedLecture(lectureInfos);
   };
-  const getLectureInfos = (infos: Array<LectureInfos>) => {
-    if (!infos) return <></>;
-    return infos.map((elem: LectureInfos) => {
+
+  const getLectureInfos = (lectureInfoDatas: Array<LectureInfos>): JSX.Element[] => {
+    if (!lectureInfoDatas) return [];
+
+    return lectureInfoDatas.map((lectureInfoData: LectureInfos) => {
       return (
         <LectureInfo
-          key={`${elem.code}${elem.class}`}
-          infos={elem}
+          key={`${lectureInfoData.code}${lectureInfoData.class}`}
+          infos={lectureInfoData}
           onDoubleClick={isBasketList ? onBasketLectureDoubleClickListener : onLectureSearchDoubleClickListener}
           onClick={isBasketList ? onBasketLectureClickListener : onLectureSearchClickListener}
           isBasketList={isBasketList}

--- a/client/src/components/UI/organisms/TimeTableMenu/TimeTableMenu.tsx
+++ b/client/src/components/UI/organisms/TimeTableMenu/TimeTableMenu.tsx
@@ -8,30 +8,6 @@ const TimeTableMenu = (): JSX.Element => {
   const { timeTableStore, modalStore } = useStores();
   const tables = useReactiveVar(timeTableStore.state.tables);
   const selectedTab = useReactiveVar(timeTableStore.state.selectedTabIdx);
-  const mockTables = [
-    {
-      index: 1,
-      name: '시간표1',
-    },
-    {
-      index: 2,
-      name: '시간표2',
-    },
-    {
-      index: 3,
-      name: '시간표3',
-    },
-    {
-      index: 4,
-      name: '시간표4',
-    },
-    {
-      index: 5,
-      name: '시간표5',
-    },
-  ];
-
-  const mockSeletedTab = 1;
 
   const onTimeTableTabChangeListener = (e: React.ChangeEvent<{}>, newValue: number): void => {
     timeTableStore.selectTab(newValue);

--- a/client/src/components/pages/MainPage.tsx
+++ b/client/src/components/pages/MainPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { AlertSnackbar } from '@/components/UI/atoms';
 import { Timetable, Notice, SearchBar, SubTitle, LectureSearchFilterMenu, TimeTableAddForm } from '@/components/UI/molecules';
-import { Box, makeStyles } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core';
 import { Header, LectureList, ModalPopup, TimeTableMenu } from '@/components/UI/organisms';
 
 const useStyles = makeStyles({
@@ -33,15 +33,15 @@ const MainPage = (): JSX.Element => {
   const classes = useStyles();
   return (
     <>
-      <Box className={classes.root}>
+      <div className={classes.root}>
         <Header />
-        <Box className={classes.wrapper}>
-          <Box className={classes.left}>
+        <div className={classes.wrapper}>
+          <div className={classes.left}>
             <Notice />
             <TimeTableMenu />
             <Timetable row={10} containedSat={false} />
-          </Box>
-          <Box className={classes.right}>
+          </div>
+          <div className={classes.right}>
             <SubTitle>강의 찾기</SubTitle>
             <SearchBar />
             <LectureSearchFilterMenu />
@@ -50,11 +50,11 @@ const MainPage = (): JSX.Element => {
             <TimeTableAddForm />
             <SubTitle>장바구니</SubTitle>
             <LectureList isBasketList />
-          </Box>
-        </Box>
+          </div>
+        </div>
         <AlertSnackbar />
         <ModalPopup />
-      </Box>
+      </div>
     </>
   );
 };

--- a/client/src/components/pages/MainPage.tsx
+++ b/client/src/components/pages/MainPage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { AlertSnackbar } from '@/components/UI/atoms';
 import { Timetable, Notice, SearchBar, SubTitle, LectureSearchFilterMenu, TimeTableAddForm } from '@/components/UI/molecules';
 import { makeStyles } from '@material-ui/core';
-import { Header, LectureList, ModalPopup, TimeTableMenu } from '@/components/UI/organisms';
+import { LectureList, ModalPopup, TimeTableMenu } from '@/components/UI/organisms';
 
 const useStyles = makeStyles({
   root: {
@@ -34,7 +34,6 @@ const MainPage = (): JSX.Element => {
   return (
     <>
       <div className={classes.root}>
-        <Header />
         <div className={classes.wrapper}>
           <div className={classes.left}>
             <Notice />

--- a/client/src/components/pages/MyPage.tsx
+++ b/client/src/components/pages/MyPage.tsx
@@ -1,12 +1,19 @@
 import React from 'react';
-import { Header } from '@/components/UI/organisms';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles({
+  root: {
+    minHeight: '1000px',
+  },
+});
 
 const MyPage = (): JSX.Element => {
+  const classes = useStyles();
+
   return (
-    <>
-      <Header />
+    <div className={classes.root}>
       <div>마이페이지</div>
-    </>
+    </div>
   );
 };
 

--- a/client/src/components/pages/ReviewPage.tsx
+++ b/client/src/components/pages/ReviewPage.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable react/no-array-index-key */
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import { Header, LectureReviewContainer } from '@/components/UI/organisms';
+import { LectureReviewContainer } from '@/components/UI/organisms';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -9,6 +8,7 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'center',
+    minHeight: '1000px',
   },
 }));
 
@@ -16,7 +16,6 @@ const ReviewPage = (): JSX.Element => {
   const classes = useStyles();
   return (
     <div className={classes.root}>
-      <Header />
       <LectureReviewContainer />
     </div>
   );

--- a/client/src/router/Router.tsx
+++ b/client/src/router/Router.tsx
@@ -1,14 +1,18 @@
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
-import { MainPage, ReviewPage, MyPage } from '../components/pages';
+import { MainPage, ReviewPage, MyPage } from '@/components/pages';
+import { Header } from '@/components/UI/organisms';
 
 function Router(): JSX.Element {
   return (
-    <Switch>
-      <Route exact path="/" component={MainPage} />
-      <Route path="/review" component={ReviewPage} />
-      <Route path="/my" component={MyPage} />
-    </Switch>
+    <>
+      <Header />
+      <Switch>
+        <Route exact path="/review" component={ReviewPage} />
+        <Route exact path="/my" component={MyPage} />
+        <Route path="/" component={MainPage} />
+      </Switch>
+    </>
   );
 }
 


### PR DESCRIPTION
## 📑 제목

#70  전체 코드 리팩토링


## 💬 작업 내용

> 구현 내용 및 작업 했던 내역
 
 수정한 파일들이 많아서 컴포넌트 단위로 commit을 나눠놓았습니다. 혹시 수정내용이 궁금하시다면 해당 commit을 참조해주세요!

- [x] 함수명, 변수명 명확하게 네이밍 변경 (이후 작성하는 코드는 아래 룰을 지켜봅시다!, Wiki 코딩 컨벤션에도 추가해놓을게요)
      - 이벤트 리스너 : handler => listener
      - boolean 변수 : 'is'를 앞에 prefix
      - boolean 체크 함수 : 'check'를 앞에 prefix
      - 컴포넌트의 리스트를 가져오는 함수 : fill => 'get'을 앞에 prefix
      - 그 외 변수나 함수는 상황에 맞게 명확하게 변경 (다시 코드 파일을 열어보았을 때, 그 파일만으로 유추가능하게끔 변경)
- [x] 가독성을 위한 코드 띄어쓰기
- [x] Timetable 컴포넌트 주석 처리된 로직 삭제 및 로직을 간결하게 변경
- [x] 컴포넌트 props 타입 정의시 any 타입들을 명확한 타입으로 변경
- [x] 라우팅 컴포넌트 렌더링 최적화
       - 라우팅시 페이지 컴포넌트들만 렌더링하도록 header 컴포넌트를 라우팅 이전 단계로 이동 


## 🚧 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 유틸함수로 분리가능해보이는 로직들은 별도의 이슈로 처리예정 (타입 체크, 유효성 검사 등)
- 컴포넌트의 네이밍은 최대한 명확하게 변경했지만, 스토어와 관련된 변수의 네이밍은 명확하게 변경하지 못했습니다. 스토어 관련 코드들은 서버 API 연동 후, 데이터 구조가 결정되면 수정해야할 듯 합니다!
- **헤더 컴포넌트를 이동하면서 페이지 스크롤 여부에 따라 헤더가 움직이는 현상이 다시 발생합니다!**
   - 해결해보려 했으나, position이 fixed인 관계로 padding을 주어서 해결하는 것은 한계가 있었습니다.
   - modalStore와 연동하여 동적으로, 모달창이 열렸을 때(스크롤이 사라졌을 때) padding을 주는 시도로 접근해보았지만, padding을 주는 속도보다 스크롤이 다시 생기는 속도가 느려서 움직이는 현상이 존재합니다.
   - 제 생각인데 PC 버전에서 height가 그리 크지도 않은데, 헤더가 fixed일 필요가 없다고 생각이 듭니다. 모바일 뷰에서만 fixed로 변경하는 것은 어떠신가요?
- 코드들이 띄어쓰기가 안되어서 가독성이 좋지 않은 부분들이 많이 발견했습니다! 혹시 진혁님 에디터에서 띄어쓰기가 안되나용??