### PR TITLE
JS 타입 체크 모듈 정의

### DIFF
--- a/client/src/__test__/common/utils/typeCheck.test.ts
+++ b/client/src/__test__/common/utils/typeCheck.test.ts
@@ -1,0 +1,169 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { isString, isNumber, isBoolean, isNull, isUndefined, isObject, isArray, isDate, isFunction } from '@/common/utils/typeCheck';
+
+describe('TypeCheck Util Test', () => {
+  const TEST_CASE = {
+    stringCase: 'string',
+    numberCase: 0,
+    booleanCase: true,
+    nullCase: null,
+    undefindedCase: undefined,
+    objectCase: {},
+    arrayCase: [],
+    dateCase: new Date(),
+    functionCase: () => {},
+  };
+
+  describe('isString() test', () => {
+    test('인자가 string 타입이면 true를, 아니면 false를 반환한다.', () => {
+      // given
+      // when
+      // then
+      expect(isString(TEST_CASE.stringCase)).toEqual(true);
+      expect(isString(TEST_CASE.numberCase)).toEqual(false);
+      expect(isString(TEST_CASE.booleanCase)).toEqual(false);
+      expect(isString(TEST_CASE.nullCase)).toEqual(false);
+      expect(isString(TEST_CASE.undefindedCase)).toEqual(false);
+      expect(isString(TEST_CASE.objectCase)).toEqual(false);
+      expect(isString(TEST_CASE.arrayCase)).toEqual(false);
+      expect(isString(TEST_CASE.dateCase)).toEqual(false);
+      expect(isString(TEST_CASE.functionCase)).toEqual(false);
+    });
+  });
+
+  describe('isNumber() test', () => {
+    test('인자가 number 타입이면 true를, 아니면 false를 반환한다.', () => {
+      // given
+      // when
+      // then
+      expect(isNumber(TEST_CASE.numberCase)).toEqual(true);
+      expect(isNumber(TEST_CASE.stringCase)).toEqual(false);
+      expect(isNumber(TEST_CASE.booleanCase)).toEqual(false);
+      expect(isNumber(TEST_CASE.nullCase)).toEqual(false);
+      expect(isNumber(TEST_CASE.undefindedCase)).toEqual(false);
+      expect(isNumber(TEST_CASE.objectCase)).toEqual(false);
+      expect(isNumber(TEST_CASE.arrayCase)).toEqual(false);
+      expect(isNumber(TEST_CASE.dateCase)).toEqual(false);
+      expect(isNumber(TEST_CASE.functionCase)).toEqual(false);
+    });
+  });
+
+  describe('isBoolean() test', () => {
+    test('인자가 boolean 타입이면 true를, 아니면 false를 반환한다.', () => {
+      // given
+      // when
+      // then
+      expect(isBoolean(TEST_CASE.booleanCase)).toEqual(true);
+      expect(isBoolean(TEST_CASE.numberCase)).toEqual(false);
+      expect(isBoolean(TEST_CASE.stringCase)).toEqual(false);
+      expect(isBoolean(TEST_CASE.nullCase)).toEqual(false);
+      expect(isBoolean(TEST_CASE.undefindedCase)).toEqual(false);
+      expect(isBoolean(TEST_CASE.objectCase)).toEqual(false);
+      expect(isBoolean(TEST_CASE.arrayCase)).toEqual(false);
+      expect(isBoolean(TEST_CASE.dateCase)).toEqual(false);
+      expect(isBoolean(TEST_CASE.functionCase)).toEqual(false);
+    });
+  });
+
+  describe('isNull() test', () => {
+    test('인자가 null 타입이면 true를, 아니면 false를 반환한다.', () => {
+      // given
+      // when
+      // then
+      expect(isNull(TEST_CASE.nullCase)).toEqual(true);
+      expect(isNull(TEST_CASE.booleanCase)).toEqual(false);
+      expect(isNull(TEST_CASE.numberCase)).toEqual(false);
+      expect(isNull(TEST_CASE.stringCase)).toEqual(false);
+      expect(isNull(TEST_CASE.undefindedCase)).toEqual(false);
+      expect(isNull(TEST_CASE.objectCase)).toEqual(false);
+      expect(isNull(TEST_CASE.arrayCase)).toEqual(false);
+      expect(isNull(TEST_CASE.dateCase)).toEqual(false);
+      expect(isNull(TEST_CASE.functionCase)).toEqual(false);
+    });
+  });
+
+  describe('isUndefined() test', () => {
+    test('인자가 undefined 타입이면 true를, 아니면 false를 반환한다.', () => {
+      // given
+      // when
+      // then
+      expect(isUndefined(TEST_CASE.undefindedCase)).toEqual(true);
+      expect(isUndefined(TEST_CASE.nullCase)).toEqual(false);
+      expect(isUndefined(TEST_CASE.booleanCase)).toEqual(false);
+      expect(isUndefined(TEST_CASE.numberCase)).toEqual(false);
+      expect(isUndefined(TEST_CASE.stringCase)).toEqual(false);
+      expect(isUndefined(TEST_CASE.objectCase)).toEqual(false);
+      expect(isUndefined(TEST_CASE.arrayCase)).toEqual(false);
+      expect(isUndefined(TEST_CASE.dateCase)).toEqual(false);
+      expect(isUndefined(TEST_CASE.functionCase)).toEqual(false);
+    });
+  });
+
+  describe('isObject() test', () => {
+    test('인자가 object 타입이면 true를, 아니면 false를 반환한다.', () => {
+      // given
+      // when
+      // then
+      expect(isObject(TEST_CASE.objectCase)).toEqual(true);
+      expect(isObject(TEST_CASE.undefindedCase)).toEqual(false);
+      expect(isObject(TEST_CASE.nullCase)).toEqual(false);
+      expect(isObject(TEST_CASE.booleanCase)).toEqual(false);
+      expect(isObject(TEST_CASE.numberCase)).toEqual(false);
+      expect(isObject(TEST_CASE.stringCase)).toEqual(false);
+      expect(isObject(TEST_CASE.arrayCase)).toEqual(false);
+      expect(isObject(TEST_CASE.dateCase)).toEqual(false);
+      expect(isObject(TEST_CASE.functionCase)).toEqual(false);
+    });
+  });
+
+  describe('isArray() test', () => {
+    test('인자가 array 타입이면 true를, 아니면 false를 반환한다.', () => {
+      // given
+      // when
+      // then
+      expect(isArray(TEST_CASE.arrayCase)).toEqual(true);
+      expect(isArray(TEST_CASE.objectCase)).toEqual(false);
+      expect(isArray(TEST_CASE.undefindedCase)).toEqual(false);
+      expect(isArray(TEST_CASE.nullCase)).toEqual(false);
+      expect(isArray(TEST_CASE.booleanCase)).toEqual(false);
+      expect(isArray(TEST_CASE.numberCase)).toEqual(false);
+      expect(isArray(TEST_CASE.stringCase)).toEqual(false);
+      expect(isArray(TEST_CASE.dateCase)).toEqual(false);
+      expect(isArray(TEST_CASE.functionCase)).toEqual(false);
+    });
+  });
+
+  describe('isDate() test', () => {
+    test('인자가 date 타입이면 true를, 아니면 false를 반환한다.', () => {
+      // given
+      // when
+      // then
+      expect(isDate(TEST_CASE.dateCase)).toEqual(true);
+      expect(isDate(TEST_CASE.objectCase)).toEqual(false);
+      expect(isDate(TEST_CASE.undefindedCase)).toEqual(false);
+      expect(isDate(TEST_CASE.nullCase)).toEqual(false);
+      expect(isDate(TEST_CASE.booleanCase)).toEqual(false);
+      expect(isDate(TEST_CASE.numberCase)).toEqual(false);
+      expect(isDate(TEST_CASE.stringCase)).toEqual(false);
+      expect(isDate(TEST_CASE.arrayCase)).toEqual(false);
+      expect(isDate(TEST_CASE.functionCase)).toEqual(false);
+    });
+  });
+
+  describe('isFunction() test', () => {
+    test('인자가 function 타입이면 true를, 아니면 false를 반환한다.', () => {
+      // given
+      // when
+      // then
+      expect(isFunction(TEST_CASE.functionCase)).toEqual(true);
+      expect(isFunction(TEST_CASE.dateCase)).toEqual(false);
+      expect(isFunction(TEST_CASE.objectCase)).toEqual(false);
+      expect(isFunction(TEST_CASE.undefindedCase)).toEqual(false);
+      expect(isFunction(TEST_CASE.nullCase)).toEqual(false);
+      expect(isFunction(TEST_CASE.booleanCase)).toEqual(false);
+      expect(isFunction(TEST_CASE.numberCase)).toEqual(false);
+      expect(isFunction(TEST_CASE.stringCase)).toEqual(false);
+      expect(isFunction(TEST_CASE.arrayCase)).toEqual(false);
+    });
+  });
+});

--- a/client/src/common/utils/index.ts
+++ b/client/src/common/utils/index.ts
@@ -1,3 +1,4 @@
 export { default as range } from './range';
 export * from './scroll';
 export { default as debounce } from './debounce';
+export * from './typeCheck';

--- a/client/src/common/utils/typeCheck.ts
+++ b/client/src/common/utils/typeCheck.ts
@@ -1,0 +1,43 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function getType(target: any): string {
+  return Object.prototype.toString.call(target).slice(8, -1);
+}
+
+function isString(target: any): boolean {
+  return getType(target) === 'String';
+}
+
+function isNumber(target: any): boolean {
+  return getType(target) === 'Number';
+}
+
+function isBoolean(target: any): boolean {
+  return getType(target) === 'Boolean';
+}
+
+function isNull(target: any): boolean {
+  return getType(target) === 'Null';
+}
+
+function isUndefined(target: any): boolean {
+  return getType(target) === 'Undefined';
+}
+
+function isObject(target: any): boolean {
+  return getType(target) === 'Object';
+}
+
+function isArray(target: any): boolean {
+  return getType(target) === 'Array';
+}
+
+function isDate(target: any): boolean {
+  return getType(target) === 'Date';
+}
+
+function isFunction(target: any): boolean {
+  return getType(target) === 'Function';
+}
+
+export { isString, isNumber, isBoolean, isNull, isUndefined, isObject, isArray, isDate, isFunction };

--- a/client/src/components/UI/molecules/LectureBoxContainer/LectureBoxContainer.tsx
+++ b/client/src/components/UI/molecules/LectureBoxContainer/LectureBoxContainer.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { LectureBox, SameLectureBox } from '@/components/UI/atoms';
+import { TimeTypes } from '@/components/UI/molecules';
 import { useStores } from '@/stores';
 import { useReactiveVar } from '@apollo/client';
+import { isString } from '@/common/utils/typeCheck';
 
 const useStyles = makeStyles({
   root: {
@@ -28,9 +30,11 @@ const LectureBoxContainer = (): JSX.Element => {
     if (!lectureInfos) return <></>;
 
     return lectureInfos.map((lectureInfo) => {
-      if (typeof lectureInfo.time === 'string') return <></>;
+      if (isString(lectureInfo.time)) return <></>;
 
-      return lectureInfo.time.map((time) => {
+      const times = lectureInfo.time as TimeTypes[];
+
+      return times.map((time) => {
         return (
           <LectureBox
             startTime={time.start}

--- a/client/src/components/UI/molecules/LectureInfo/LectureInfo.tsx
+++ b/client/src/components/UI/molecules/LectureInfo/LectureInfo.tsx
@@ -4,6 +4,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import { LectureInfoTitle, LectureInfoTitleType, LectureInfoDivider } from '@/components/UI/atoms';
 import { useStores } from '@/stores';
 import { useReactiveVar } from '@apollo/client';
+import { isString } from '@/common/utils/typeCheck';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -104,9 +105,9 @@ const LectureInfo = ({ isHeader = false, infos, onDoubleClick, onClick, isBasket
   };
 
   const getLectureTimes = (times: Array<TimeTypes> | string): JSX.Element[] | string => {
-    if (typeof times === 'string') return times;
+    if (isString(times)) return times as string;
 
-    return times.map((time) => {
+    return (times as TimeTypes[]).map((time) => {
       return (
         <Typography key={time.start} variant="caption">
           {convertTimeToString(time)}

--- a/client/src/components/UI/organisms/LectureList/LectureList.tsx
+++ b/client/src/components/UI/organisms/LectureList/LectureList.tsx
@@ -4,6 +4,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import { SnackbarType } from '@/components/UI/atoms';
 import { LectureInfo, LectureInfos, BasketLectureListBody, SearchedLectureListBody } from '@/components/UI/molecules';
 import { useStores } from '@/stores';
+import { isString } from '@/common/utils/typeCheck';
 
 interface LectureListProps {
   isBasketList?: boolean;
@@ -49,7 +50,7 @@ const LectureList = ({ isBasketList = false }: LectureListProps): JSX.Element =>
   const { timeTableStore, snackbarStore, lectureInfoStore } = useStores();
 
   const onLectureSearchDoubleClickListener = (lectureInfos: LectureInfos) => {
-    if (typeof lectureInfos.time === 'string') return;
+    if (isString(lectureInfos.time)) return;
 
     timeTableStore.addLectureToTable(lectureInfos);
     snackbarStore.setSnackbarType(SnackbarType.ADD_SUCCESS);
@@ -57,7 +58,7 @@ const LectureList = ({ isBasketList = false }: LectureListProps): JSX.Element =>
   };
 
   const onBasketLectureDoubleClickListener = (lectureInfos: LectureInfos) => {
-    if (typeof lectureInfos.time === 'string') return;
+    if (isString(lectureInfos.time)) return;
 
     timeTableStore.removeLectureFromTable(lectureInfos.name);
     snackbarStore.setSnackbarType(SnackbarType.DELETE_SUCCESS);
@@ -65,13 +66,13 @@ const LectureList = ({ isBasketList = false }: LectureListProps): JSX.Element =>
   };
 
   const onLectureSearchClickListener = (lectureInfos: LectureInfos) => {
-    if (typeof lectureInfos.time === 'string') return;
+    if (isString(lectureInfos.time)) return;
 
     lectureInfoStore.state.selectedLecture(lectureInfos);
   };
 
   const onBasketLectureClickListener = (lectureInfos: LectureInfos) => {
-    if (typeof lectureInfos.time === 'string') return;
+    if (isString(lectureInfos.time)) return;
 
     lectureInfoStore.state.basketSelectedLecture(lectureInfos);
   };


### PR DESCRIPTION
## 📑 제목

#78 Javascript 타입을 검사하는 코드는 자주 사용되므로 타입 체크 모듈 정의


## 💬 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] **typeCheck 모듈 함수 정의**
- 명확한 타입 검사를 위해서 toString 함수를 이용해서 타입을 검사하도록 수정
    - Function과 같이 세밀한 타입 검사를 위해서 typeof 가 아닌 toString 활용
    - Symbol, BigInt와 같이 불필요한 원시 타입 체크는 고려 x
    - Array, Date 이외에 자주 사용되지 않을 내장 타입은 고려 x
    - 상속관계 비교는 아직까지는 불필요해보여서 고려 x
       - 고려한다면 종종 이벤트 핸들러에서 Element인지 검사를 많이 하는데 아래와 같이 사용도 가능해보입니다.
```
function isElement(target) {
      return !!(target && target instanceof HTMLElement);
}
```
- [x] **typeCheck 모듈 함수 테스트 코드 작성**
- [x] **JS 타입 검사 로직을 typeCheck 모듈 함수를 활용하도록 코드 수정**

## 🚧 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 컴포넌트 타입 체크 로직을 수정한 부분을 참고해보시면 typeCheck 모듈 내부에서 toString으로 타입을 체크하여서 그런지 타입스크립트에서 타입 추론에 영향을 주지 않습니다! 타입 단언을 통해서 임시로 코드를 수정했지만, 깔끔하지 못해서 아쉬운 생각이 드네요! 