### PR TITLE
Form 데이터 유효성 검사 유틸 모듈 제작

### DIFF
--- a/client/src/__test__/common/utils/validator.test.ts
+++ b/client/src/__test__/common/utils/validator.test.ts
@@ -1,0 +1,81 @@
+import { isEmailID, isPassword, isName } from '@/common/utils/validator';
+
+describe('Validator Util Test', () => {
+  const checkTestCases = (testFunc: Function, testCases: string[], equalValue: boolean) => {
+    testCases.forEach((testCase) => {
+      expect(testFunc(testCase)).toEqual(equalValue);
+    });
+  };
+
+  describe('isEmailID() test', () => {
+    test('이메일 아이디는 1자리 이상 12자리 이하여야한다.', () => {
+      // given
+      // when
+      const validCases = ['a', 'test12345', 'test', 'testtesttest'];
+      const inValidCases = ['', 'testtesttesttesttest'];
+
+      // then
+      checkTestCases(isEmailID, validCases, true);
+      checkTestCases(isEmailID, inValidCases, false);
+    });
+
+    test('이메일 아이디는 영소문자, 숫자, _ 로만 조합된 문자열만 가능하다.', () => {
+      // given
+      // when
+      const validCases = ['abc', '1234', '_', 'abc123', '__abc123'];
+      const inValidCases = ['~!@#$%^&*()', 'test1234!', '@test1234', 'Te##!@st', '테스트', '테스트1234', '테스트Test1234', 'Test', 'ABCD'];
+
+      // then
+      checkTestCases(isEmailID, validCases, true);
+      checkTestCases(isEmailID, inValidCases, false);
+    });
+  });
+
+  describe('isPassword() test', () => {
+    test('패스워드는 8자리 이상 12자리 이하여야한다.', () => {
+      // given
+      // when
+      const validCases = ['test1234!', '123test!@#', '%%%1234test', 'TESTtest12!'];
+      const inValidCases = ['', 'test12!', 'testtest', 'test!@#$', '!@#!@#$', '12345678'];
+
+      // then
+      checkTestCases(isPassword, validCases, true);
+      checkTestCases(isPassword, inValidCases, false);
+    });
+
+    test('패스워드는 영문, 특수문자, 숫자 모두 최소 1개 이상으로 조합된 문자열만 가능하다.', () => {
+      // given
+      // when
+      const validCases = ['testTEST12!@', '!@12testTEST', 'test123!@', '123test!@'];
+      const inValidCases = ['~!@#$%^&*()', '12341234', 'testtest', 'TESTTEST', '테스트테스트!!', '테스트Test1234', 'Test1234', 'test!@#$'];
+
+      // then
+      checkTestCases(isPassword, validCases, true);
+      checkTestCases(isPassword, inValidCases, false);
+    });
+  });
+
+  describe('isName() test', () => {
+    test('이름은 2자 이상이여야 한다.', () => {
+      // given
+      // when
+      const validCases = ['김훈', '홍길동', '모나리자'];
+      const inValidCases = ['', '김'];
+
+      // then
+      checkTestCases(isName, validCases, true);
+      checkTestCases(isName, inValidCases, false);
+    });
+
+    test('이름은 한글로 조합된 문자열만 가능하다.', () => {
+      // given
+      // when
+      const validCases = ['김훈', '홍길동', '모나리자'];
+      const inValidCases = ['', 'name', 'NAME', '김name', '1234', '김1234', '!@#$', '김!@#$#'];
+
+      // then
+      checkTestCases(isName, validCases, true);
+      checkTestCases(isName, inValidCases, false);
+    });
+  });
+});

--- a/client/src/common/utils/validator.ts
+++ b/client/src/common/utils/validator.ts
@@ -1,0 +1,31 @@
+// 한표(한기대 포털 이메일) 아이디 제약조건
+// 영소문자, 숫자, _ 로만 조합된 문자열만 가능
+// 최소 1자리 이상 12자리 이하
+
+// 한표 패스워드 제약조건
+// 8자 이상 12자 이하
+// 영문, 특수문자, 숫자 모두 최소 1개 이상 포함
+
+// 한표 이름 제약조건
+// 2자 이상
+// 한글만 가능
+
+const REGEX = {
+  EMAIL_ID: /^[a-z0-9_][a-z0-9_]{0,11}$/,
+  PASSWORD: /^(?=.*[a-zA-z])(?=.*[0-9])(?=.*[$`~!@$!%*#^?&\\(\\)\-_=+]).{8,12}$/,
+  NAME: /^[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]{2,}$/,
+};
+
+const isEmailID = (formValue: string): boolean => {
+  return REGEX.EMAIL_ID.test(formValue);
+};
+
+const isPassword = (formValue: string): boolean => {
+  return REGEX.PASSWORD.test(formValue);
+};
+
+const isName = (formValue: string): boolean => {
+  return REGEX.NAME.test(formValue);
+};
+
+export { isEmailID, isPassword, isName };

--- a/client/src/components/UI/molecules/LoginModalContent/LoginModalContent.tsx
+++ b/client/src/components/UI/molecules/LoginModalContent/LoginModalContent.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Button, DialogTitle, DialogContent, DialogActions, TextField } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import { debounce } from '@/common/utils';
+import { isEmailID, isPassword } from '@/common/utils/validator';
 
 enum LoginModalType {
   LOGIN_MODAL = 'LOGIN_MODAL',
@@ -20,6 +21,17 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+const HELPER_TEXT = {
+  EMAIL: {
+    DEFAULT: 'koreatech.ac.kr은 빼고 입력해주세요.',
+    ERROR: 'Email 형식이 적합하지 않습니다.',
+  },
+  PASSWORD: {
+    DEFAULT: 'Password는 8자 이상 12자 이하로 입력해주세요.',
+    ERROR: 'Password 형식이 적합하지 않습니다.',
+  },
+};
+
 const LoginModalContent = ({ onModalClose }: LoginModalContentProps): JSX.Element => {
   const classes = useStyles();
   const [email, setEmail] = useState('');
@@ -28,15 +40,17 @@ const LoginModalContent = ({ onModalClose }: LoginModalContentProps): JSX.Elemen
   const [isValidPassword, setIsValidPassword] = useState(true);
 
   const onDebouncedEmailChangeListener = debounce((e: React.ChangeEvent<HTMLInputElement>) => {
-    setEmail(e.target.value);
-    if ((e.target.value.length !== 0 && e.target.value.length < 8) || e.target.value.length > 12) setIsValidEmail(false);
-    else setIsValidEmail(true);
+    const { value: emailIDValue } = e.target;
+
+    setEmail(emailIDValue);
+    setIsValidEmail(isEmailID(emailIDValue));
   }, 500);
 
   const onDebouncedPasswordChangeListener = debounce((e: React.ChangeEvent<HTMLInputElement>) => {
-    setPassword(e.target.value);
-    if ((e.target.value.length !== 0 && e.target.value.length < 8) || e.target.value.length > 12) setIsValidPassword(false);
-    else setIsValidPassword(true);
+    const { value: passwordValue } = e.target;
+
+    setPassword(passwordValue);
+    setIsValidPassword(isPassword(passwordValue));
   }, 500);
 
   return (
@@ -47,7 +61,7 @@ const LoginModalContent = ({ onModalClose }: LoginModalContentProps): JSX.Elemen
       <DialogContent>
         <TextField
           autoComplete="off"
-          helperText={isValidEmail ? 'koreatech.ac.kr은 빼고 입력해주세요.' : 'Email 형식이 적합하지 않습니다.'}
+          helperText={isValidEmail ? HELPER_TEXT.EMAIL.DEFAULT : HELPER_TEXT.EMAIL.ERROR}
           error={!isValidEmail}
           autoFocus
           margin="dense"
@@ -59,7 +73,7 @@ const LoginModalContent = ({ onModalClose }: LoginModalContentProps): JSX.Elemen
         />
         <TextField
           autoComplete="off"
-          helperText={isValidPassword ? 'Password는 8자 이상 12자 이하로 입력해주세요.' : 'Password 형식이 적합하지 않습니다.'}
+          helperText={isValidPassword ? HELPER_TEXT.PASSWORD.DEFAULT : HELPER_TEXT.PASSWORD.ERROR}
           error={!isValidPassword}
           margin="dense"
           id="password"

--- a/client/src/components/UI/molecules/SignUpModalContent/SignUpModalContent.tsx
+++ b/client/src/components/UI/molecules/SignUpModalContent/SignUpModalContent.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Button, DialogTitle, DialogContent, DialogActions, TextField } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import { debounce } from '@/common/utils';
+import { isEmailID, isPassword, isName } from '@/common/utils/validator';
 
 enum SignUpModalType {
   SIGN_UP_MODAL = 'SIGN_UP_MODAL',
@@ -20,23 +21,49 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+const HELPER_TEXT = {
+  EMAIL: {
+    DEFAULT: 'koreatech.ac.kr은 빼고 입력해주세요.',
+    ERROR: 'Email 형식이 적합하지 않습니다.',
+  },
+  PASSWORD: {
+    DEFAULT: 'Password는 8자 이상 12자 이하로 입력해주세요.',
+    ERROR: 'Password 형식이 적합하지 않습니다.',
+  },
+  NAME: {
+    DEFAULT: '이름은 2자 이상 입력해주세요.',
+    ERROR: '이름 형식이 적합하지 않습니다.',
+  },
+};
+
 const SignUpModalContent = ({ onModalClose }: SignUpModalContentProps): JSX.Element => {
   const classes = useStyles();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [name, setName] = useState('');
   const [isValidEmail, setIsValidEmail] = useState(true);
   const [isValidPassword, setIsValidPassword] = useState(true);
+  const [isValidName, setIsValidName] = useState(true);
 
   const onDebouncedEmailChangeListener = debounce((e: React.ChangeEvent<HTMLInputElement>) => {
-    setEmail(e.target.value);
-    if ((e.target.value.length !== 0 && e.target.value.length < 8) || e.target.value.length > 12) setIsValidEmail(false);
-    else setIsValidEmail(true);
+    const { value: emailIDValue } = e.target;
+
+    setEmail(emailIDValue);
+    setIsValidEmail(isEmailID(emailIDValue));
   }, 500);
 
   const onDebouncedPasswordChangeListener = debounce((e: React.ChangeEvent<HTMLInputElement>) => {
-    setPassword(e.target.value);
-    if ((e.target.value.length !== 0 && e.target.value.length < 8) || e.target.value.length > 12) setIsValidPassword(false);
-    else setIsValidPassword(true);
+    const { value: passwordValue } = e.target;
+
+    setPassword(passwordValue);
+    setIsValidPassword(isPassword(passwordValue));
+  }, 500);
+
+  const onDebouncedNameChangeListener = debounce((e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value: nameValue } = e.target;
+
+    setName(nameValue);
+    setIsValidName(isName(nameValue));
   }, 500);
 
   return (
@@ -47,7 +74,7 @@ const SignUpModalContent = ({ onModalClose }: SignUpModalContentProps): JSX.Elem
       <DialogContent>
         <TextField
           autoComplete="off"
-          helperText={isValidEmail ? 'koreatech.ac.kr은 빼고 입력해주세요.' : 'Email 형식이 적합하지 않습니다.'}
+          helperText={isValidEmail ? HELPER_TEXT.EMAIL.DEFAULT : HELPER_TEXT.EMAIL.ERROR}
           error={!isValidEmail}
           autoFocus
           margin="dense"
@@ -59,7 +86,7 @@ const SignUpModalContent = ({ onModalClose }: SignUpModalContentProps): JSX.Elem
         />
         <TextField
           autoComplete="off"
-          helperText={isValidPassword ? 'Password는 8자 이상 12자 이하로 입력해주세요.' : 'Password 형식이 적합하지 않습니다.'}
+          helperText={isValidPassword ? HELPER_TEXT.PASSWORD.DEFAULT : HELPER_TEXT.PASSWORD.ERROR}
           error={!isValidPassword}
           margin="dense"
           id="password"
@@ -68,7 +95,17 @@ const SignUpModalContent = ({ onModalClose }: SignUpModalContentProps): JSX.Elem
           fullWidth
           onChange={onDebouncedPasswordChangeListener}
         />
-        <TextField autoComplete="off" margin="dense" id="name" label="이름" type="text" fullWidth />
+        <TextField
+          autoComplete="off"
+          helperText={isValidName ? HELPER_TEXT.NAME.DEFAULT : HELPER_TEXT.NAME.ERROR}
+          error={!isValidName}
+          margin="dense"
+          id="name"
+          label="이름"
+          type="text"
+          fullWidth
+          onChange={onDebouncedNameChangeListener}
+        />
         <TextField autoComplete="off" margin="dense" id="nickname" label="닉네임" type="text" fullWidth />
       </DialogContent>
       <DialogActions>


### PR DESCRIPTION
## 📑 제목

#79 Form 데이터 유효성 검사 유틸 모듈 제작


## 💬 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] **validator 유틸 모듈 제작**
  - 정규표현식을 활용하여 제약조건에 따른 유효성 검사 모듈 함수 제작
  - 이메일 아이디 제약조건 : 한기대 포털 아이디 제약 조건 (영소문자, 숫자, _ 로만 조합된 문자열, 1자 이상 12자 이하)
  - 패스워드 제약조건 : 8자 이상 12자 이하 + 영문, 특수문자, 숫자 모두 최소 1개 이상 포함하도록 수정
  - 이름 제약 조건 : 2자 이상 한글만 가능하도록 수정
- [x] **validator 유틸 모듈 테스트 코드 작성**
- [x] **회원가입, 로그인 폼 유효성 검사 로직에서 validator 모듈을 활용하도록 수정**
- [x]  **LoginModalContent, SignUpModalContent 컴포넌트 helperText 메세지 상수 처리**


## 🚧 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 한기대 포털 사이트에서 회원가입 절차를 테스트하면서 아이디 제약조건을 테스트하고, 유효성 검사로직에 반영했습니다.
- validator 모듈에 유효성 검사 제약조건에 대한 '주석'을 남겼습니다. 유효성 검사 제약조건에 대한 내용은 주석으로 남겨서 관리하는 것이 코드 유지보수에 도움이 될 것 같아서요! validator 모듈에서 제약조건 내용을 확인해주세요!
- 회원가입 폼에서 이름에 대한 제약조건과 유효성검사를 추가했습니다.
- 이전 코드와 마찬가지로 닉네임에 대한 제약조건은 따로 두지 않았습니다! 아직까지는 불필요해 보이네요!