### PR TITLE
강의 후기 디테일 모달 창 제작

### DIFF
--- a/client/src/components/UI/atoms/HashTag/HashTag.tsx
+++ b/client/src/components/UI/atoms/HashTag/HashTag.tsx
@@ -15,6 +15,7 @@ const useStyles = makeStyles((theme) => ({
     borderRadius: '1rem',
     padding: '0rem 0.5rem',
     marginRight: '0.5rem',
+    marginTop: '0.3rem',
     backgroundColor: 'white',
   },
 }));

--- a/client/src/components/UI/atoms/ThumbScore/ThumbScore.tsx
+++ b/client/src/components/UI/atoms/ThumbScore/ThumbScore.tsx
@@ -8,6 +8,7 @@ interface ThumbProps {
   thumbDown?: boolean;
   score: number;
   onClick?: () => void;
+  detail: boolean;
 }
 
 interface CSSProps {
@@ -28,20 +29,27 @@ const useStyles = makeStyles((theme) => ({
   }),
   down: {
     color: '#F15F5F',
-    marginRight: '0.2rem',
   },
   up: {
     color: '#6799FF',
+  },
+  marginRight: {
     marginRight: '0.2rem',
   },
 }));
 
-const Thumb = ({ thumbDown = false, score, onClick }: ThumbProps): JSX.Element => {
+const Thumb = ({ thumbDown = false, score, onClick, detail }: ThumbProps): JSX.Element => {
   const classes = useStyles({ thumbDown });
   return (
     <div className={classes.root} onClick={onClick}>
-      {thumbDown ? <ThumbDown fontSize="small" className={classes.down} /> : <ThumbUp fontSize="small" className={classes.up} />}
-      <Typography>{score}</Typography>
+      {thumbDown ? (
+        <ThumbDown fontSize={detail ? 'large' : 'small'} className={`${classes.down} ${classes.marginRight}`} />
+      ) : (
+        <ThumbUp fontSize={detail ? 'large' : 'small'} className={`${classes.up} ${classes.marginRight}`} />
+      )}
+      <Typography className={thumbDown ? classes.down : classes.up} variant={detail ? 'h6' : 'subtitle2'}>
+        {score}
+      </Typography>
     </div>
   );
 };

--- a/client/src/components/UI/molecules/LectureReviewHashTags/LectureReviewHashTags.tsx
+++ b/client/src/components/UI/molecules/LectureReviewHashTags/LectureReviewHashTags.tsx
@@ -9,6 +9,7 @@ interface LectureReviewHashTagsProps {
 const useStyles = makeStyles((theme) => ({
   root: {
     display: 'flex',
+    flexWrap: 'wrap',
   },
 }));
 

--- a/client/src/components/UI/molecules/LectureReviewThumbs/LectureReviewThumbs.tsx
+++ b/client/src/components/UI/molecules/LectureReviewThumbs/LectureReviewThumbs.tsx
@@ -5,6 +5,7 @@ import { Thumb } from '@/components/UI/atoms';
 interface LectureReviewThumbsProps {
   upScore: number;
   downScore: number;
+  detail?: boolean;
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -13,12 +14,12 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const LectureReviewThumbs = ({ upScore, downScore }: LectureReviewThumbsProps): JSX.Element => {
+const LectureReviewThumbs = ({ upScore, downScore, detail = false }: LectureReviewThumbsProps): JSX.Element => {
   const classes = useStyles();
   return (
     <div className={classes.root}>
-      <Thumb score={upScore} />
-      <Thumb score={downScore} thumbDown />
+      <Thumb score={upScore} detail={detail} />
+      <Thumb score={downScore} thumbDown detail={detail} />
     </div>
   );
 };

--- a/client/src/components/UI/molecules/ReviewDetailModalContent/ReviewDetailModalContent.stories.tsx
+++ b/client/src/components/UI/molecules/ReviewDetailModalContent/ReviewDetailModalContent.stories.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import { action } from '@storybook/addon-actions';
+import { withStoryBox } from '@/components/HOC';
+import { ReviewDetailModalContent, ReviewDetailModalType, ReviewDetailModalContentProps } from './ReviewDetailModalContent';
+
+export default {
+  title: 'molecules/ReviewDetailModalContent',
+  component: ReviewDetailModalContent,
+  decorators: [withKnobs],
+} as Meta;
+
+const mockData = {
+  id: 0,
+  infos: {
+    lectureName: '디자인커뮤니케이션',
+    profName: '윤정식',
+    rating: 3.5,
+    period: '2020년도 2학기',
+  },
+  content:
+    'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur unde suscipit, quam beatae rerum inventore consectetur, neque doloribus, cupiditate numquam dignissimos laborum fugiat deleniti? Eum quasi quidem quibusdam. 안녕하세요 제 이름은 지녀쿠입니다. 한기대학생이 아니지만 한표를 만들고 있답니다 하하',
+  tags: ['꿀수업', '진혀쿠', '돔황챠', '진혀쿠', '돔황챠', '진혀쿠', '돔황챠', '진혀쿠', '돔황챠', '진혀쿠', '돔황챠', '진혀쿠', '돔황챠'],
+  scores: {
+    upScore: 20,
+    downScore: 3,
+  },
+};
+
+const Template: Story<ReviewDetailModalContentProps> = (args) => {
+  const ReviewDetailModalContentStory = withStoryBox(args, 700)(ReviewDetailModalContent);
+  return <ReviewDetailModalContentStory />;
+};
+
+export const OthersReviewDetail = Template.bind({});
+OthersReviewDetail.args = {
+  data: mockData,
+  modalType: ReviewDetailModalType.REVIEW_DETAIL_MODAL,
+  onModalClose: action('onClick'),
+  onModalModifyBtnClick: action('onClick'),
+  onModalDeleteBtnClick: action('onClick'),
+};
+
+export const MyReviewDetail = Template.bind({});
+MyReviewDetail.args = {
+  data: mockData,
+  modalType: ReviewDetailModalType.REVIEW_DETAIL_MODAL,
+  onModalClose: action('onClick'),
+  isMine: true,
+  onModalModifyBtnClick: action('onClick'),
+  onModalDeleteBtnClick: action('onClick'),
+};

--- a/client/src/components/UI/molecules/ReviewDetailModalContent/ReviewDetailModalContent.tsx
+++ b/client/src/components/UI/molecules/ReviewDetailModalContent/ReviewDetailModalContent.tsx
@@ -1,0 +1,50 @@
+import React, { useState, useEffect } from 'react';
+import { Button, DialogTitle, DialogContent, DialogActions, Typography, Divider } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import { LectureReviewData } from '@/components/UI/organisms';
+
+enum ReviewDetailModalType {
+  REVIEW_DETAIL_MODAL = 'REVIEW_DETAIL_MODAL',
+}
+
+interface ReviewDetailModalContentProps {
+  data: LectureReviewData;
+  isMine?: boolean;
+  onModalClose: () => void;
+}
+
+const useStyles = makeStyles((theme) => ({
+  title: {
+    display: 'flex',
+    flexDirection: 'column',
+  },
+}));
+
+const ReviewDetailModalContent = ({ data, isMine = false, onModalClose }: ReviewDetailModalContentProps): JSX.Element => {
+  const classes = useStyles();
+
+  return (
+    <>
+      <DialogTitle className={classes.title} id="login-dialog-title" disableTypography>
+        <div>
+          <Typography>{data.infos.lectureName}</Typography>
+          <Typography>{data.infos.profName}</Typography>
+        </div>
+        <div>
+          <Typography>{data.infos.period}</Typography>
+          <Divider orientation="horizontal" />
+          <Typography>날짜</Typography>
+        </div>
+      </DialogTitle>
+      <DialogContent>내용</DialogContent>
+      <DialogActions>
+        <Button onClick={onModalClose} color="primary">
+          로그인
+        </Button>
+      </DialogActions>
+    </>
+  );
+};
+
+export { ReviewDetailModalContent, ReviewDetailModalType };
+export type { ReviewDetailModalContentProps };

--- a/client/src/components/UI/molecules/ReviewDetailModalContent/ReviewDetailModalContent.tsx
+++ b/client/src/components/UI/molecules/ReviewDetailModalContent/ReviewDetailModalContent.tsx
@@ -1,6 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Button, DialogTitle, DialogContent, DialogActions, Typography, Divider } from '@material-ui/core';
+import Close from '@material-ui/icons/Close';
 import { makeStyles } from '@material-ui/core/styles';
+import { LectureReviewRating } from '@/components/UI/atoms';
+import { LectureReviewThumbs, LectureReviewHashTags } from '@/components/UI/molecules';
 import { LectureReviewData } from '@/components/UI/organisms';
 
 enum ReviewDetailModalType {
@@ -11,6 +14,8 @@ interface ReviewDetailModalContentProps {
   data: LectureReviewData;
   isMine?: boolean;
   onModalClose: () => void;
+  onModalModifyBtnClick: () => void;
+  onModalDeleteBtnClick: () => void;
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -18,29 +23,112 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
     flexDirection: 'column',
   },
+  titleTopArea1: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  titleTopArea2: {
+    display: 'flex',
+    width: '40%',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  normalFlexBox: {
+    display: 'flex',
+  },
+  closeBtn: {
+    color: theme.palette.grey[400],
+    '&:hover': {
+      cursor: 'pointer',
+      opacity: 0.7,
+    },
+  },
+  action: {
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  actionThumbs: {
+    marginLeft: 'auto',
+  },
+  actionButtons: {
+    display: 'flex',
+    width: '100%',
+    justifyContent: 'space-between',
+  },
+  modifyButton: {
+    backgroundColor: theme.palette.primary.main,
+    width: '45%',
+    color: 'white',
+    borderRadius: '1rem',
+    '&:hover': {
+      backgroundColor: theme.palette.primary.main,
+      opacity: 0.7,
+    },
+  },
+  deleteButton: {
+    width: '45%',
+    backgroundColor: theme.palette.secondary.main,
+    borderRadius: '1rem',
+    '&:hover': {
+      backgroundColor: theme.palette.secondary.main,
+      opacity: 0.7,
+    },
+  },
+  divider: {
+    margin: '0 0.5rem',
+  },
 }));
 
-const ReviewDetailModalContent = ({ data, isMine = false, onModalClose }: ReviewDetailModalContentProps): JSX.Element => {
+const ReviewDetailModalContent = ({
+  data,
+  isMine = false,
+  onModalClose,
+  onModalModifyBtnClick,
+  onModalDeleteBtnClick,
+}: ReviewDetailModalContentProps): JSX.Element => {
   const classes = useStyles();
 
   return (
     <>
       <DialogTitle className={classes.title} id="login-dialog-title" disableTypography>
-        <div>
-          <Typography>{data.infos.lectureName}</Typography>
-          <Typography>{data.infos.profName}</Typography>
+        <div className={classes.titleTopArea1}>
+          <div className={classes.titleTopArea2}>
+            <Typography variant="h6">{data.infos.lectureName}</Typography>
+            <Typography>{data.infos.profName}</Typography>
+          </div>
+          <Close className={classes.closeBtn} onClick={onModalClose} />
+        </div>
+        <div className={classes.normalFlexBox}>
+          <Typography variant="caption">{data.infos.period}</Typography>
+          <Divider className={classes.divider} orientation="vertical" flexItem />
+          <Typography variant="caption">작성 날짜</Typography>
+        </div>
+        <div className={classes.normalFlexBox}>
+          <Typography>평점</Typography>
+          <LectureReviewRating rating={data.infos.rating} />
         </div>
         <div>
-          <Typography>{data.infos.period}</Typography>
-          <Divider orientation="horizontal" />
-          <Typography>날짜</Typography>
+          <LectureReviewHashTags tags={data.tags} />
         </div>
       </DialogTitle>
-      <DialogContent>내용</DialogContent>
-      <DialogActions>
-        <Button onClick={onModalClose} color="primary">
-          로그인
-        </Button>
+      <DialogContent>
+        <Typography variant="body2">{data.content}</Typography>
+      </DialogContent>
+      <DialogActions className={classes.action}>
+        <div className={classes.actionThumbs}>
+          <LectureReviewThumbs upScore={data.scores.upScore} downScore={data.scores.downScore} detail />
+        </div>
+        {isMine && (
+          <div className={classes.actionButtons}>
+            <Button className={classes.modifyButton} onClick={onModalModifyBtnClick}>
+              수 정
+            </Button>
+            <Button className={classes.deleteButton} onClick={onModalDeleteBtnClick}>
+              삭 제
+            </Button>
+          </div>
+        )}
       </DialogActions>
     </>
   );

--- a/client/src/components/UI/molecules/index.ts
+++ b/client/src/components/UI/molecules/index.ts
@@ -27,3 +27,4 @@ export { LectureReviewThumbs } from './LectureReviewThumbs/LectureReviewThumbs';
 export type { LectureReviewThumbsProps } from './LectureReviewThumbs/LectureReviewThumbs';
 export { LectureReviewHashTags } from './LectureReviewHashTags/LectureReviewHashTags';
 export { ReviewSearchSection } from './ReviewSearchSection/ReviewSearchSection';
+export { ReviewDetailModalContent, ReviewDetailModalType } from './ReviewDetailModalContent/ReviewDetailModalContent';

--- a/client/src/components/UI/organisms/LectureReview/LectureReview.stories.tsx
+++ b/client/src/components/UI/organisms/LectureReview/LectureReview.stories.tsx
@@ -10,6 +10,23 @@ export default {
   decorators: [withKnobs],
 } as Meta;
 
+const mockData = {
+  id: 0,
+  infos: {
+    lectureName: '디자인커뮤니케이션',
+    profName: '윤정식',
+    rating: 3.5,
+    period: '2020년도 2학기',
+  },
+  content:
+    'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur unde suscipit, quam beatae rerum inventore consectetur, neque doloribus, cupiditate numquam dignissimos laborum fugiat deleniti? Eum quasi quidem quibusdam. 안녕하세요 제 이름은 지녀쿠입니다. 한기대학생이 아니지만 한표를 만들고 있답니다 하하',
+  tags: ['꿀수업', '진혀쿠', '돔황챠', '진혀쿠', '돔황챠', '진혀쿠', '돔황챠', '진혀쿠', '돔황챠', '진혀쿠', '돔황챠', '진혀쿠', '돔황챠'],
+  scores: {
+    upScore: 20,
+    downScore: 3,
+  },
+};
+
 const Template: Story<LectureReviewProps> = (args) => {
   const LectureReviewStory = withStoryBox(args, 800)(LectureReview);
   return <LectureReviewStory {...args} />;
@@ -17,33 +34,11 @@ const Template: Story<LectureReviewProps> = (args) => {
 
 export const MyReview = Template.bind({});
 MyReview.args = {
-  infos: {
-    lectureName: '취준하며놀고먹기',
-    profName: '진혀쿠',
-    rating: 1.5,
-    period: '2021년도 1학기',
-  },
-  content: '취준하면서 놀고 먹고 싶다구요? 저처럼 공부를 안 하면 된답니다!',
-  tags: ['백수', '진혀쿠', '나처럼살지마'],
-  scores: {
-    upScore: 5,
-    downScore: 18,
-  },
+  data: mockData,
   isMine: true,
 };
 
 export const OthersReview = Template.bind({});
 OthersReview.args = {
-  infos: {
-    lectureName: '멋지게취업하기',
-    profName: '갓우진',
-    rating: 5,
-    period: '2021년도 1학기',
-  },
-  content: '나는야 갓우진 그린팩토리를 점령할 사람이지!',
-  tags: ['취뽀', '신과함께'],
-  scores: {
-    upScore: 1000,
-    downScore: 0,
-  },
+  data: mockData,
 };

--- a/client/src/components/UI/organisms/LectureReview/LectureReview.tsx
+++ b/client/src/components/UI/organisms/LectureReview/LectureReview.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/UI/molecules';
 
 interface LectureReviewData {
+  id: number;
   infos: LectureReviewInfoProps;
   content: string;
   tags: string[];
@@ -17,7 +18,6 @@ interface LectureReviewData {
 
 interface LectureReviewProps {
   data: LectureReviewData;
-  onClick: (infos: LectureReviewProps) => void;
   isMine?: boolean;
 }
 
@@ -64,11 +64,11 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const LectureReview = ({ data, onClick, isMine = false }: LectureReviewProps): JSX.Element => {
+const LectureReview = ({ data, isMine = false }: LectureReviewProps): JSX.Element => {
   const classes = useStyles({ isMine });
 
   return (
-    <div className={classes.root} onClick={() => onClick}>
+    <span className={classes.root} data-id={data.id}>
       <div className={classes.header}>
         <LectureReviewInfo
           lectureName={data.infos.lectureName}
@@ -82,7 +82,7 @@ const LectureReview = ({ data, onClick, isMine = false }: LectureReviewProps): J
       <div className={classes.bottom}>
         <LectureReviewHashTags tags={data.tags} />
       </div>
-    </div>
+    </span>
   );
 };
 

--- a/client/src/components/UI/organisms/LectureReview/LectureReview.tsx
+++ b/client/src/components/UI/organisms/LectureReview/LectureReview.tsx
@@ -8,11 +8,16 @@ import {
   LectureReviewThumbsProps,
 } from '@/components/UI/molecules';
 
-interface LectureReviewProps {
+interface LectureReviewData {
   infos: LectureReviewInfoProps;
   content: string;
   tags: string[];
   scores: LectureReviewThumbsProps;
+}
+
+interface LectureReviewProps {
+  data: LectureReviewData;
+  onClick: (infos: LectureReviewProps) => void;
   isMine?: boolean;
 }
 
@@ -59,22 +64,27 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const LectureReview = ({ infos, content, tags, scores, isMine = false }: LectureReviewProps): JSX.Element => {
+const LectureReview = ({ data, onClick, isMine = false }: LectureReviewProps): JSX.Element => {
   const classes = useStyles({ isMine });
 
   return (
-    <div className={classes.root}>
+    <div className={classes.root} onClick={() => onClick}>
       <div className={classes.header}>
-        <LectureReviewInfo lectureName={infos.lectureName} profName={infos.profName} rating={infos.rating} period={infos.period} />
-        <LectureReviewThumbs upScore={scores.upScore} downScore={scores.downScore} />
+        <LectureReviewInfo
+          lectureName={data.infos.lectureName}
+          profName={data.infos.profName}
+          rating={data.infos.rating}
+          period={data.infos.period}
+        />
+        <LectureReviewThumbs upScore={data.scores.upScore} downScore={data.scores.downScore} />
       </div>
-      <div className={classes.content}>{content}</div>
+      <div className={classes.content}>{data.content}</div>
       <div className={classes.bottom}>
-        <LectureReviewHashTags tags={tags} />
+        <LectureReviewHashTags tags={data.tags} />
       </div>
     </div>
   );
 };
 
 export { LectureReview };
-export type { LectureReviewProps };
+export type { LectureReviewProps, LectureReviewData };

--- a/client/src/components/UI/organisms/LectureReview/LectureReviewContainer.tsx
+++ b/client/src/components/UI/organisms/LectureReview/LectureReviewContainer.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable react/no-array-index-key */
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
+import { useReactiveVar } from '@apollo/client';
+import { useStores } from '@/stores';
 import { LectureReview } from './LectureReview';
 
 const useStyles = makeStyles({
@@ -10,59 +12,16 @@ const useStyles = makeStyles({
   },
 });
 
-const mockData = [
-  {
-    infos: {
-      lectureName: '디자인커뮤니케이션',
-      profName: '윤정식',
-      rating: 3.5,
-      period: '2020년도 2학기',
-    },
-    content:
-      'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur unde suscipit, quam beatae rerum inventore consectetur, neque doloribus, cupiditate numquam dignissimos laborum fugiat deleniti? Eum quasi quidem quibusdam. 안녕하세요 제 이름은 지녀쿠입니다. 한기대학생이 아니지만 한표를 만들고 있답니다 하하',
-    tags: ['꿀수업', '진혀쿠', '돔황챠'],
-    scores: {
-      upScore: 20,
-      downScore: 3,
-    },
-  },
-  {
-    infos: {
-      lectureName: '취준하며놀고먹기',
-      profName: '진혀쿠',
-      rating: 1.5,
-      period: '2021년도 1학기',
-    },
-    content: '취준하면서 놀고 먹고 싶다구요? 저처럼 공부를 안 하면 된답니다!',
-    tags: ['백수', '진혀쿠', '나처럼살지마'],
-    scores: {
-      upScore: 5,
-      downScore: 18,
-    },
-    isMine: true,
-  },
-  {
-    infos: {
-      lectureName: '디자인커뮤니케이션',
-      profName: '윤정식',
-      rating: 4,
-      period: '2020년도 2학기',
-    },
-    content:
-      'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur unde suscipit, quam beatae rerum inventore consectetur, neque doloribus, cupiditate numquam dignissimos laborum fugiat deleniti? Eum quasi quidem quibusdam. 안녕하세요 제 이름은 지녀쿠입니다. 한기대학생이 아니지만 한표를 만들고 있답니다 하하',
-    tags: ['꿀수업', '진혀쿠', '돔황챠'],
-    scores: {
-      upScore: 20,
-      downScore: 3,
-    },
-  },
-];
-
 const LectureReviewContainer = (): JSX.Element => {
   const classes = useStyles();
+  const { lectureReviewStore } = useStores();
+  const reviews = useReactiveVar(lectureReviewStore.state.reviews);
+
   const getLectureReviews = () => {
-    return mockData.map((data, idx) => {
-      return <LectureReview key={idx} infos={data.infos} content={data.content} tags={data.tags} scores={data.scores} isMine={data.isMine} />;
+    return reviews.map((review, idx) => {
+      return (
+        <LectureReview key={idx} infos={review.infos} content={review.content} tags={review.tags} scores={review.scores} isMine={review.isMine} />
+      );
     });
   };
   return <div className={classes.root}>{getLectureReviews()}</div>;

--- a/client/src/components/UI/organisms/LectureReview/LectureReviewContainer.tsx
+++ b/client/src/components/UI/organisms/LectureReview/LectureReviewContainer.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { useReactiveVar } from '@apollo/client';
 import { useStores } from '@/stores';
-import { LectureReview } from './LectureReview';
+import { modalTypes } from '@/components/UI/organisms';
+import { LectureReview, LectureReviewData } from './LectureReview';
 
 const useStyles = makeStyles({
   root: {
@@ -14,17 +15,35 @@ const useStyles = makeStyles({
 
 const LectureReviewContainer = (): JSX.Element => {
   const classes = useStyles();
-  const { lectureReviewStore } = useStores();
+  const { lectureReviewStore, modalStore } = useStores();
   const reviews = useReactiveVar(lectureReviewStore.state.reviews);
 
+  const onClickListener = (event: React.MouseEvent<HTMLElement>) => {
+    const target = event.target as HTMLElement;
+    const spanElement = target.closest('span');
+
+    if (!spanElement) return;
+
+    const { dataset } = spanElement;
+    lectureReviewStore.state.nowSelectedReviewId(Number(dataset?.id));
+    modalStore.changeModalState(modalTypes.REVIEW_DETAIL_MODAL, true);
+  };
+
+  const checkIsMine = () => {
+    // LectureReview의 writer와 서버로부터 받아온 내 닉네임을 비교하여 true/false 반환
+    // 클라이언트에서 닉네임을 관리하게 될 경우 문제가 생길 수 있을 것 같음
+    // 클라이언트에서 닉네임을 악의적으로 바꿔 글을 수정하는 것을 방지하기 위해 서버에서 한 번 더 검사하면 좋을 듯
+  };
   const getLectureReviews = () => {
     return reviews.map((review, idx) => {
-      return (
-        <LectureReview key={idx} infos={review.infos} content={review.content} tags={review.tags} scores={review.scores} isMine={review.isMine} />
-      );
+      return <LectureReview key={idx} data={review} />;
     });
   };
-  return <div className={classes.root}>{getLectureReviews()}</div>;
+  return (
+    <div className={classes.root} onClick={onClickListener}>
+      {getLectureReviews()}
+    </div>
+  );
 };
 
 export { LectureReviewContainer };

--- a/client/src/components/UI/organisms/ModalPopup/ModalPopup.tsx
+++ b/client/src/components/UI/organisms/ModalPopup/ModalPopup.tsx
@@ -1,15 +1,16 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import React from 'react';
-import { TimeTableModalType, LoginModalType, SignUpModalType } from '@/components/UI/molecules';
+import { TimeTableModalType, LoginModalType, SignUpModalType, ReviewDetailModalType } from '@/components/UI/molecules';
 import { useStores } from '@/stores';
 import { useReactiveVar } from '@apollo/client';
 import { TimeTableModalPopup } from './TimeTableModalPopup';
 import { LoginModalPopup } from './LoginModalPopup';
 import { SignUpModalPopup } from './SignUpModalPopup';
+import { ReviewDetailModalPopup } from './ReviewDetailModalPopup';
 
-type ModalType = TimeTableModalType | LoginModalType | SignUpModalType;
+type ModalType = TimeTableModalType | LoginModalType | SignUpModalType | ReviewDetailModalType;
 
-const modalTypes = { ...TimeTableModalType, ...LoginModalType, ...SignUpModalType };
+const modalTypes = { ...TimeTableModalType, ...LoginModalType, ...SignUpModalType, ...ReviewDetailModalType };
 
 const ModalPopup = (): JSX.Element => {
   const { timeTableStore, modalStore } = useStores();
@@ -52,7 +53,8 @@ const ModalPopup = (): JSX.Element => {
       );
     if (nowModalType === modalTypes.SIGN_UP_MODAL)
       return <SignUpModalPopup modalOpen={nowModalState} onModalBtnClick={() => {}} onModalAreaClose={onModalCloseListener} />;
-
+    if (nowModalType === modalTypes.REVIEW_DETAIL_MODAL)
+      return <ReviewDetailModalPopup modalOpen={nowModalState} onModalBtnClick={() => {}} onModalAreaClose={onModalCloseListener} />;
     return <LoginModalPopup modalOpen={nowModalState} onModalBtnClick={() => {}} onModalAreaClose={onModalCloseListener} />;
   };
 

--- a/client/src/components/UI/organisms/ModalPopup/ModalPopup.tsx
+++ b/client/src/components/UI/organisms/ModalPopup/ModalPopup.tsx
@@ -54,7 +54,14 @@ const ModalPopup = (): JSX.Element => {
     if (nowModalType === modalTypes.SIGN_UP_MODAL)
       return <SignUpModalPopup modalOpen={nowModalState} onModalBtnClick={() => {}} onModalAreaClose={onModalCloseListener} />;
     if (nowModalType === modalTypes.REVIEW_DETAIL_MODAL)
-      return <ReviewDetailModalPopup modalOpen={nowModalState} onModalBtnClick={() => {}} onModalAreaClose={onModalCloseListener} />;
+      return (
+        <ReviewDetailModalPopup
+          modalOpen={nowModalState}
+          onModalModifyBtnClick={() => {}}
+          onModalDeleteBtnClick={() => {}}
+          onModalAreaClose={onModalCloseListener}
+        />
+      );
     return <LoginModalPopup modalOpen={nowModalState} onModalBtnClick={() => {}} onModalAreaClose={onModalCloseListener} />;
   };
 

--- a/client/src/components/UI/organisms/ModalPopup/ReviewDetailModalPopup.tsx
+++ b/client/src/components/UI/organisms/ModalPopup/ReviewDetailModalPopup.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { ModalPopupArea, ReviewDetailModalContent } from '@/components/UI/molecules';
+import { useStores } from '@/stores';
+
+interface ReviewDetailModalPopupProps {
+  modalOpen: boolean;
+  onModalAreaClose: () => void;
+  onModalBtnClick: () => void;
+}
+
+const ReviewDetailModalPopup = ({ modalOpen, onModalAreaClose, onModalBtnClick }: ReviewDetailModalPopupProps): JSX.Element => {
+  const { lectureReviewStore } = useStores();
+  return (
+    <ModalPopupArea modalOpen={modalOpen} onModalClose={onModalAreaClose}>
+      <ReviewDetailModalContent data={lectureReviewStore.getNowSelectedReview()} onModalClose={onModalBtnClick} />
+    </ModalPopupArea>
+  );
+};
+
+export { ReviewDetailModalPopup };
+export type { ReviewDetailModalPopupProps };

--- a/client/src/components/UI/organisms/ModalPopup/ReviewDetailModalPopup.tsx
+++ b/client/src/components/UI/organisms/ModalPopup/ReviewDetailModalPopup.tsx
@@ -5,14 +5,25 @@ import { useStores } from '@/stores';
 interface ReviewDetailModalPopupProps {
   modalOpen: boolean;
   onModalAreaClose: () => void;
-  onModalBtnClick: () => void;
+  onModalModifyBtnClick: () => void;
+  onModalDeleteBtnClick: () => void;
 }
 
-const ReviewDetailModalPopup = ({ modalOpen, onModalAreaClose, onModalBtnClick }: ReviewDetailModalPopupProps): JSX.Element => {
+const ReviewDetailModalPopup = ({
+  modalOpen,
+  onModalAreaClose,
+  onModalModifyBtnClick,
+  onModalDeleteBtnClick,
+}: ReviewDetailModalPopupProps): JSX.Element => {
   const { lectureReviewStore } = useStores();
   return (
     <ModalPopupArea modalOpen={modalOpen} onModalClose={onModalAreaClose}>
-      <ReviewDetailModalContent data={lectureReviewStore.getNowSelectedReview()} onModalClose={onModalBtnClick} />
+      <ReviewDetailModalContent
+        data={lectureReviewStore.getNowSelectedReview()}
+        onModalClose={onModalAreaClose}
+        onModalModifyBtnClick={onModalModifyBtnClick}
+        onModalDeleteBtnClick={onModalDeleteBtnClick}
+      />
     </ModalPopupArea>
   );
 };

--- a/client/src/components/UI/organisms/index.ts
+++ b/client/src/components/UI/organisms/index.ts
@@ -5,3 +5,4 @@ export type { LectureListProps } from './LectureList/LectureList';
 export { Header } from './Header/Header';
 export { TimeTableMenu } from './TimeTableMenu/TimeTableMenu';
 export { LectureReviewContainer } from './LectureReview/LectureReviewContainer';
+export type { LectureReviewProps, LectureReviewData } from './LectureReview/LectureReview';

--- a/client/src/components/pages/ReviewPage.tsx
+++ b/client/src/components/pages/ReviewPage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { Typography, Button } from '@material-ui/core';
 import { ReviewSearchSection } from '@/components/UI/molecules';
-import { LectureReviewContainer } from '@/components/UI/organisms';
+import { LectureReviewContainer, ModalPopup } from '@/components/UI/organisms';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -45,22 +45,25 @@ const useStyles = makeStyles((theme) => ({
 const ReviewPage = (): JSX.Element => {
   const classes = useStyles();
   return (
-    <div className={classes.root}>
-      <div className={classes.wrapper}>
-        <div className={classes.titleArea}>
-          <Typography variant="h4" color="primary">
-            강의 후기
-          </Typography>
-          <Button className={classes.writeButton} variant="contained" color="primary">
-            강의 후기 쓰기
-          </Button>
+    <>
+      <div className={classes.root}>
+        <div className={classes.wrapper}>
+          <div className={classes.titleArea}>
+            <Typography variant="h4" color="primary">
+              강의 후기
+            </Typography>
+            <Button className={classes.writeButton} variant="contained" color="primary">
+              강의 후기 쓰기
+            </Button>
+          </div>
+          <div className={classes.searchArea}>
+            <ReviewSearchSection />
+          </div>
+          <LectureReviewContainer />
         </div>
-        <div className={classes.searchArea}>
-          <ReviewSearchSection />
-        </div>
-        <LectureReviewContainer />
       </div>
-    </div>
+      <ModalPopup />
+    </>
   );
 };
 

--- a/client/src/stores/LectureReviewStore.ts
+++ b/client/src/stores/LectureReviewStore.ts
@@ -4,7 +4,7 @@ import { LectureReviewData } from '@/components/UI/organisms';
 
 interface LectureReviewStoreState {
   reviews: ReactiveVar<LectureReviewData[]>;
-  nowSelectedReviewData: ReactiveVar<LectureReviewData | null>;
+  nowSelectedReviewId: ReactiveVar<number>;
 }
 
 class LectureReviewStore {
@@ -16,13 +16,13 @@ class LectureReviewStore {
     this.rootStore = rootStore;
     this.state = {
       reviews: makeVar<LectureReviewData[]>(mockData),
-      nowSelectedReviewData: makeVar<LectureReviewData | null>(null),
+      nowSelectedReviewId: makeVar<number>(0),
     };
   }
 
-  getNowSelectedReview(id: number) {
-    const { reviews } = this.state;
-    return reviews()[id];
+  getNowSelectedReview() {
+    const { reviews, nowSelectedReviewId } = this.state;
+    return reviews()[nowSelectedReviewId()];
   }
 }
 

--- a/client/src/stores/LectureReviewStore.ts
+++ b/client/src/stores/LectureReviewStore.ts
@@ -19,10 +19,16 @@ class LectureReviewStore {
       nowSelectedReviewData: makeVar<LectureReviewData | null>(null),
     };
   }
+
+  getNowSelectedReview(id: number) {
+    const { reviews } = this.state;
+    return reviews()[id];
+  }
 }
 
 const mockData = [
   {
+    id: 0,
     infos: {
       lectureName: '디자인커뮤니케이션',
       profName: '윤정식',
@@ -38,6 +44,7 @@ const mockData = [
     },
   },
   {
+    id: 1,
     infos: {
       lectureName: '취준하며놀고먹기',
       profName: '진혀쿠',
@@ -53,6 +60,7 @@ const mockData = [
     isMine: true,
   },
   {
+    id: 2,
     infos: {
       lectureName: '디자인커뮤니케이션',
       profName: '윤정식',

--- a/client/src/stores/LectureReviewStore.ts
+++ b/client/src/stores/LectureReviewStore.ts
@@ -1,0 +1,72 @@
+import { makeVar, ReactiveVar } from '@apollo/client';
+import { RootStore } from '@/stores';
+import { LectureReviewProps } from '@/components/UI/organisms';
+
+interface LectureReviewStoreState {
+  reviews: ReactiveVar<LectureReviewProps[]>;
+  nowSelectedReviewData: ReactiveVar<LectureReviewProps | null>;
+}
+
+class LectureReviewStore {
+  rootStore: RootStore;
+
+  state: LectureReviewStoreState;
+
+  constructor(rootStore: RootStore) {
+    this.rootStore = rootStore;
+    this.state = {
+      reviews: makeVar<LectureReviewProps[]>(mockData),
+      nowSelectedReviewData: makeVar<LectureReviewProps | null>(null),
+    };
+  }
+}
+
+const mockData = [
+  {
+    infos: {
+      lectureName: '디자인커뮤니케이션',
+      profName: '윤정식',
+      rating: 3.5,
+      period: '2020년도 2학기',
+    },
+    content:
+      'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur unde suscipit, quam beatae rerum inventore consectetur, neque doloribus, cupiditate numquam dignissimos laborum fugiat deleniti? Eum quasi quidem quibusdam. 안녕하세요 제 이름은 지녀쿠입니다. 한기대학생이 아니지만 한표를 만들고 있답니다 하하',
+    tags: ['꿀수업', '진혀쿠', '돔황챠'],
+    scores: {
+      upScore: 20,
+      downScore: 3,
+    },
+  },
+  {
+    infos: {
+      lectureName: '취준하며놀고먹기',
+      profName: '진혀쿠',
+      rating: 1.5,
+      period: '2021년도 1학기',
+    },
+    content: '취준하면서 놀고 먹고 싶다구요? 저처럼 공부를 안 하면 된답니다!',
+    tags: ['백수', '진혀쿠', '나처럼살지마'],
+    scores: {
+      upScore: 5,
+      downScore: 18,
+    },
+    isMine: true,
+  },
+  {
+    infos: {
+      lectureName: '디자인커뮤니케이션',
+      profName: '윤정식',
+      rating: 4,
+      period: '2020년도 2학기',
+    },
+    content:
+      'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur unde suscipit, quam beatae rerum inventore consectetur, neque doloribus, cupiditate numquam dignissimos laborum fugiat deleniti? Eum quasi quidem quibusdam. 안녕하세요 제 이름은 지녀쿠입니다. 한기대학생이 아니지만 한표를 만들고 있답니다 하하',
+    tags: ['꿀수업', '진혀쿠', '돔황챠'],
+    scores: {
+      upScore: 20,
+      downScore: 3,
+    },
+  },
+];
+
+export default LectureReviewStore;

--- a/client/src/stores/LectureReviewStore.ts
+++ b/client/src/stores/LectureReviewStore.ts
@@ -37,7 +37,7 @@ const mockData = [
     },
     content:
       'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur unde suscipit, quam beatae rerum inventore consectetur, neque doloribus, cupiditate numquam dignissimos laborum fugiat deleniti? Eum quasi quidem quibusdam. 안녕하세요 제 이름은 지녀쿠입니다. 한기대학생이 아니지만 한표를 만들고 있답니다 하하',
-    tags: ['꿀수업', '진혀쿠', '돔황챠'],
+    tags: ['꿀수업', '진혀쿠', '돔황챠', '진혀쿠', '돔황챠', '진혀쿠', '돔황챠', '진혀쿠', '돔황챠', '진혀쿠', '돔황챠', '진혀쿠', '돔황챠'],
     scores: {
       upScore: 20,
       downScore: 3,

--- a/client/src/stores/LectureReviewStore.ts
+++ b/client/src/stores/LectureReviewStore.ts
@@ -1,10 +1,10 @@
 import { makeVar, ReactiveVar } from '@apollo/client';
 import { RootStore } from '@/stores';
-import { LectureReviewProps } from '@/components/UI/organisms';
+import { LectureReviewData } from '@/components/UI/organisms';
 
 interface LectureReviewStoreState {
-  reviews: ReactiveVar<LectureReviewProps[]>;
-  nowSelectedReviewData: ReactiveVar<LectureReviewProps | null>;
+  reviews: ReactiveVar<LectureReviewData[]>;
+  nowSelectedReviewData: ReactiveVar<LectureReviewData | null>;
 }
 
 class LectureReviewStore {
@@ -15,8 +15,8 @@ class LectureReviewStore {
   constructor(rootStore: RootStore) {
     this.rootStore = rootStore;
     this.state = {
-      reviews: makeVar<LectureReviewProps[]>(mockData),
-      nowSelectedReviewData: makeVar<LectureReviewProps | null>(null),
+      reviews: makeVar<LectureReviewData[]>(mockData),
+      nowSelectedReviewData: makeVar<LectureReviewData | null>(null),
     };
   }
 }

--- a/client/src/stores/RootStore.ts
+++ b/client/src/stores/RootStore.ts
@@ -1,4 +1,4 @@
-import { ModalStore, TimeTableStore, SnackbarStore, LectureInfoStore } from '@/stores';
+import { ModalStore, TimeTableStore, SnackbarStore, LectureInfoStore, LectureReviewStore } from '@/stores';
 
 class RootStore {
   modalStore: ModalStore;
@@ -9,11 +9,14 @@ class RootStore {
 
   lectureInfoStore: LectureInfoStore;
 
+  lectureReviewStore: LectureReviewStore;
+
   constructor() {
     this.modalStore = new ModalStore(this);
     this.timeTableStore = new TimeTableStore(this);
     this.snackbarStore = new SnackbarStore(this);
     this.lectureInfoStore = new LectureInfoStore(this);
+    this.lectureReviewStore = new LectureReviewStore(this);
   }
 }
 

--- a/client/src/stores/index.ts
+++ b/client/src/stores/index.ts
@@ -3,4 +3,5 @@ export { default as ModalStore } from './ModalStore';
 export { default as TimeTableStore } from './TimeTableStore';
 export { default as SnackbarStore } from './SnackbarStore';
 export { default as LectureInfoStore } from './LectureInfoStore';
+export { default as LectureReviewStore } from './LectureReviewStore';
 export * from './StoreContext';


### PR DESCRIPTION
## 📑 제목

![image](https://user-images.githubusercontent.com/46101366/116241531-f52df300-a79f-11eb-8e33-21a58d734ee1.png)

이미지와 같이 강의 후기 디테일 모달 창을 제작했습니다.

데이터 전달은 우진님께서 추천해주신 것처럼 강의 리뷰마다 id를 배정하고 클릭 이벤트가 발생하면 id를 store에 저장하여 기존 review들에서 클릭된 리뷰를 찾아서 전달하는 방식입니다.

작성자를 확인하는 부분은 일단 props에 따라 view가 달라지는 처리만 해뒀습니다.

네이밍을 통일시킬까 합니다. 현재 저희 서비스에서 Review는 강의 리뷰밖에 없기 때문에 Lecture를 빼고 Review로 바로 시작할까 생각중입니다. 괜찮으시다면 다음 작업에서 모두 Review로 시작하게 통일 시키겠습니다.
## 💬 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] LectureReview Store 정의
- [x] ReviewDetailModal 제작
- [x] 몇몇 컴포넌트에 대해 재사용을 위한 리팩토링 작업 진행


## 🚧 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 원래 이번 PR에서 다 해결하려 했으나 작업량이 좀 많아질 것 같아 따로 이슈를 파서 작업하고자 하는 내용들입니다.
  - LectureReview의 id를 찾아가는 과정에서 span 태그를 찾게 했는데 Typography가 span으로 처리되어 클릭 위치에 따라 에러가 날 때가 있습니다. 이를 해결하기 위해 LectureReview를 감싸는 최상위 div에 class 명을 부여하고 해당 class를 찾아 DOM 조작을 하려 했는데 현재 방식으로는 에러가 납니다. 다른 방법을 찾아서 해결해보겠습니다.
  - 강의 후기 페이지에 min-width가 설정되어 있어 Layout이 이상해진 문제와 SearchBar의 marginTop을 없애서 메인 페이지에서의 Layout이 이상해진 문제
  - hashtag가 많을 경우 LectureReview의 범위를 벗어나는 문제가 있는데 일정 수보다 늘어나면 or LectureReview의 width를 넘어가면 처리를 해줘야 할 것 같습니다. 생각나시는 방법 공유해주시면 참고하고싶네요!
  - 내 글인 경우 Thumbs들을 disabled 시켜야 할 것 같습니다.