### PR TITLE
강의 리뷰 클릭시 버그 제거 및 기타 등등

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>한표 :: 한기대 시간표 웹</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/client/src/components/UI/atoms/LectureReviewRating/LectureReviewRating.tsx
+++ b/client/src/components/UI/atoms/LectureReviewRating/LectureReviewRating.tsx
@@ -22,9 +22,9 @@ const LectureReviewRating = ({ rating }: LectureReviewRatingProps): JSX.Element 
     const Stars = Math.floor(rating);
     const isHalfStar = !!(rating - Stars);
     const borderStars = isHalfStar ? 4 - Stars : 5 - Stars;
-    for (let i = 0; i < Stars; i++) array.push(<Star fontSize="small" color="primary" />);
-    if (isHalfStar) array.push(<StarHalf fontSize="small" color="primary" />);
-    for (let i = 0; i < borderStars; i++) array.push(<StarBorder fontSize="small" color="primary" />);
+    for (let i = 0; i < Stars; i++) array.push(<Star key={`S${i}`} fontSize="small" color="primary" />);
+    if (isHalfStar) array.push(<StarHalf key="SH" fontSize="small" color="primary" />);
+    for (let i = 0; i < borderStars; i++) array.push(<StarBorder key={`BS${i}`} fontSize="small" color="primary" />);
     return array;
   };
 

--- a/client/src/components/UI/atoms/ThumbScore/ThumbScore.tsx
+++ b/client/src/components/UI/atoms/ThumbScore/ThumbScore.tsx
@@ -7,7 +7,7 @@ import ThumbDown from '@material-ui/icons/ThumbDownTwoTone';
 interface ThumbProps {
   thumbDown?: boolean;
   score: number;
-  onClick?: () => void;
+  onClick?: (event: React.MouseEvent<HTMLElement>) => void;
   detail: boolean;
 }
 

--- a/client/src/components/UI/molecules/LectureReviewHashTags/LectureReviewHashTags.tsx
+++ b/client/src/components/UI/molecules/LectureReviewHashTags/LectureReviewHashTags.tsx
@@ -1,9 +1,11 @@
+/* eslint-disable react/no-array-index-key */
 import React from 'react';
 import { HashTag } from '@/components/UI/atoms';
 import { makeStyles } from '@material-ui/core/styles';
 
 interface LectureReviewHashTagsProps {
   tags: string[];
+  isDetail?: boolean;
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -13,11 +15,12 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const LectureReviewHashTags = ({ tags }: LectureReviewHashTagsProps): JSX.Element => {
+const LectureReviewHashTags = ({ tags, isDetail = false }: LectureReviewHashTagsProps): JSX.Element => {
   const classes = useStyles();
   const getHashTags = () => {
-    return tags.map((tag) => {
-      return <HashTag key={tag}>{tag}</HashTag>;
+    const tempTags = isDetail ? tags : tags.slice(0, 9);
+    return tempTags.map((tag, idx) => {
+      return <HashTag key={`${idx}${tag}`}>{tag}</HashTag>;
     });
   };
   return <div className={classes.root}>{getHashTags()}</div>;

--- a/client/src/components/UI/molecules/LectureReviewThumbs/LectureReviewThumbs.tsx
+++ b/client/src/components/UI/molecules/LectureReviewThumbs/LectureReviewThumbs.tsx
@@ -6,6 +6,7 @@ interface LectureReviewThumbsProps {
   upScore: number;
   downScore: number;
   detail?: boolean;
+  isMine?: boolean;
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -14,15 +15,19 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const LectureReviewThumbs = ({ upScore, downScore, detail = false }: LectureReviewThumbsProps): JSX.Element => {
+const LectureReviewThumbs = ({ upScore, downScore, detail = false, isMine }: LectureReviewThumbsProps): JSX.Element => {
   const classes = useStyles();
 
   const onUpClickListener = (event: React.MouseEvent<HTMLElement>) => {
     event.stopPropagation();
+    if (isMine) return;
+    console.log('up click');
   };
 
   const onDownClickListener = (event: React.MouseEvent<HTMLElement>) => {
     event.stopPropagation();
+    if (isMine) return;
+    console.log('down click');
   };
 
   return (

--- a/client/src/components/UI/molecules/LectureReviewThumbs/LectureReviewThumbs.tsx
+++ b/client/src/components/UI/molecules/LectureReviewThumbs/LectureReviewThumbs.tsx
@@ -16,10 +16,19 @@ const useStyles = makeStyles((theme) => ({
 
 const LectureReviewThumbs = ({ upScore, downScore, detail = false }: LectureReviewThumbsProps): JSX.Element => {
   const classes = useStyles();
+
+  const onUpClickListener = (event: React.MouseEvent<HTMLElement>) => {
+    event.stopPropagation();
+  };
+
+  const onDownClickListener = (event: React.MouseEvent<HTMLElement>) => {
+    event.stopPropagation();
+  };
+
   return (
     <div className={classes.root}>
-      <Thumb score={upScore} detail={detail} />
-      <Thumb score={downScore} thumbDown detail={detail} />
+      <Thumb score={upScore} detail={detail} onClick={onUpClickListener} />
+      <Thumb score={downScore} thumbDown detail={detail} onClick={onDownClickListener} />
     </div>
   );
 };

--- a/client/src/components/UI/molecules/ReviewDetailModalContent/ReviewDetailModalContent.tsx
+++ b/client/src/components/UI/molecules/ReviewDetailModalContent/ReviewDetailModalContent.tsx
@@ -109,7 +109,7 @@ const ReviewDetailModalContent = ({
           <LectureReviewRating rating={data.infos.rating} />
         </div>
         <div>
-          <LectureReviewHashTags tags={data.tags} />
+          <LectureReviewHashTags tags={data.tags} isDetail />
         </div>
       </DialogTitle>
       <DialogContent>

--- a/client/src/components/UI/organisms/Footer/Footer.stories.tsx
+++ b/client/src/components/UI/organisms/Footer/Footer.stories.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import { Footer } from '@/components/UI/organisms';
+
+export default {
+  title: 'organisms/Footer',
+  component: Footer,
+  decorators: [withKnobs],
+} as Meta;
+
+const Template: Story = (args) => <Footer {...args} />;
+
+export const Default = Template.bind({});

--- a/client/src/components/UI/organisms/Footer/Footer.tsx
+++ b/client/src/components/UI/organisms/Footer/Footer.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Typography, Link } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: 'flex',
+    justifyContent: 'space-around',
+    alignItems: 'center',
+    marginTop: 'auto',
+    width: '100%',
+    height: '5rem',
+    backgroundColor: theme.palette.secondary.main,
+  },
+  text: {
+    color: theme.palette.grey[500],
+  },
+}));
+
+const Footer = (): JSX.Element => {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.root}>
+      <Link href="https://github.com/koreatech/hanpyo" className={classes.text}>
+        GitHub
+      </Link>
+      <Link href="/" className={classes.text}>
+        피드백
+      </Link>
+      <Link href="/" className={classes.text}>
+        개인정보처리방침
+      </Link>
+      <Link href="/" className={classes.text}>
+        책임의 한계와 법적 고지
+      </Link>
+      <Link href="/" className={classes.text}>
+        Contact
+      </Link>
+    </div>
+  );
+};
+
+export { Footer };

--- a/client/src/components/UI/organisms/LectureReview/LectureReview.tsx
+++ b/client/src/components/UI/organisms/LectureReview/LectureReview.tsx
@@ -19,6 +19,7 @@ interface LectureReviewData {
 interface LectureReviewProps {
   data: LectureReviewData;
   isMine?: boolean;
+  onClick: (event: React.MouseEvent<HTMLElement>) => void;
 }
 
 interface CSSProps {
@@ -64,11 +65,11 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const LectureReview = ({ data, isMine = false }: LectureReviewProps): JSX.Element => {
+const LectureReview = ({ data, isMine = false, onClick }: LectureReviewProps): JSX.Element => {
   const classes = useStyles({ isMine });
 
   return (
-    <span className={classes.root} data-id={data.id}>
+    <span className={classes.root} data-id={data.id} onClick={onClick}>
       <div className={classes.header}>
         <LectureReviewInfo
           lectureName={data.infos.lectureName}

--- a/client/src/components/UI/organisms/LectureReview/LectureReview.tsx
+++ b/client/src/components/UI/organisms/LectureReview/LectureReview.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import {
   LectureReviewInfo,
@@ -19,7 +19,7 @@ interface LectureReviewData {
 interface LectureReviewProps {
   data: LectureReviewData;
   isMine?: boolean;
-  onClick: (event: React.MouseEvent<HTMLElement>) => void;
+  onClick: (event: React.MouseEvent<HTMLElement>, ref: HTMLSpanElement | null) => void;
 }
 
 interface CSSProps {
@@ -67,9 +67,9 @@ const useStyles = makeStyles((theme) => ({
 
 const LectureReview = ({ data, isMine = false, onClick }: LectureReviewProps): JSX.Element => {
   const classes = useStyles({ isMine });
-
+  const lectureReview = useRef<HTMLSpanElement>(null);
   return (
-    <span className={classes.root} data-id={data.id} onClick={onClick}>
+    <span className={classes.root} data-id={data.id} ref={lectureReview} onClick={(event) => onClick(event, lectureReview.current)}>
       <div className={classes.header}>
         <LectureReviewInfo
           lectureName={data.infos.lectureName}

--- a/client/src/components/UI/organisms/LectureReview/LectureReviewContainer.tsx
+++ b/client/src/components/UI/organisms/LectureReview/LectureReviewContainer.tsx
@@ -19,12 +19,8 @@ const LectureReviewContainer = (): JSX.Element => {
   const reviews = useReactiveVar(lectureReviewStore.state.reviews);
 
   const onClickListener = (event: React.MouseEvent<HTMLElement>) => {
-    const target = event.target as HTMLElement;
-    const spanElement = target.closest('span');
-
-    if (!spanElement) return;
-
-    const { dataset } = spanElement;
+    const target = event.currentTarget as HTMLElement;
+    const { dataset } = target;
     lectureReviewStore.state.nowSelectedReviewId(Number(dataset?.id));
     modalStore.changeModalState(modalTypes.REVIEW_DETAIL_MODAL, true);
   };
@@ -36,14 +32,10 @@ const LectureReviewContainer = (): JSX.Element => {
   };
   const getLectureReviews = () => {
     return reviews.map((review, idx) => {
-      return <LectureReview key={idx} data={review} />;
+      return <LectureReview key={idx} data={review} onClick={onClickListener} />;
     });
   };
-  return (
-    <div className={classes.root} onClick={onClickListener}>
-      {getLectureReviews()}
-    </div>
-  );
+  return <div className={classes.root}>{getLectureReviews()}</div>;
 };
 
 export { LectureReviewContainer };

--- a/client/src/components/UI/organisms/LectureReview/LectureReviewContainer.tsx
+++ b/client/src/components/UI/organisms/LectureReview/LectureReviewContainer.tsx
@@ -4,7 +4,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import { useReactiveVar } from '@apollo/client';
 import { useStores } from '@/stores';
 import { modalTypes } from '@/components/UI/organisms';
-import { LectureReview, LectureReviewData } from './LectureReview';
+import { LectureReview } from './LectureReview';
 
 const useStyles = makeStyles({
   root: {
@@ -18,9 +18,9 @@ const LectureReviewContainer = (): JSX.Element => {
   const { lectureReviewStore, modalStore } = useStores();
   const reviews = useReactiveVar(lectureReviewStore.state.reviews);
 
-  const onClickListener = (event: React.MouseEvent<HTMLElement>) => {
-    const target = event.currentTarget as HTMLElement;
-    const { dataset } = target;
+  const onClickListener = (event: React.MouseEvent<HTMLElement>, ref: HTMLSpanElement | null) => {
+    if (!ref) return;
+    const { dataset } = ref;
     lectureReviewStore.state.nowSelectedReviewId(Number(dataset?.id));
     modalStore.changeModalState(modalTypes.REVIEW_DETAIL_MODAL, true);
   };

--- a/client/src/components/UI/organisms/index.ts
+++ b/client/src/components/UI/organisms/index.ts
@@ -6,3 +6,4 @@ export { Header } from './Header/Header';
 export { TimeTableMenu } from './TimeTableMenu/TimeTableMenu';
 export { LectureReviewContainer } from './LectureReview/LectureReviewContainer';
 export type { LectureReviewProps, LectureReviewData } from './LectureReview/LectureReview';
+export { Footer } from './Footer/Footer';

--- a/client/src/components/pages/MainPage.tsx
+++ b/client/src/components/pages/MainPage.tsx
@@ -27,6 +27,10 @@ const useStyles = makeStyles({
     alignItems: 'center',
     width: '35rem',
   },
+  marginTop: {
+    width: '100%',
+    marginTop: '1rem',
+  },
 });
 
 const MainPage = (): JSX.Element => {
@@ -42,7 +46,9 @@ const MainPage = (): JSX.Element => {
           </div>
           <div className={classes.right}>
             <SubTitle>강의 찾기</SubTitle>
-            <SearchBar />
+            <div className={classes.marginTop}>
+              <SearchBar />
+            </div>
             <LectureSearchFilterMenu />
             <LectureList />
             <SubTitle>나만의 스케줄 추가</SubTitle>

--- a/client/src/components/pages/MainPage.tsx
+++ b/client/src/components/pages/MainPage.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 import { AlertSnackbar } from '@/components/UI/atoms';
 import { Timetable, Notice, SearchBar, SubTitle, LectureSearchFilterMenu, TimeTableAddForm } from '@/components/UI/molecules';
 import { makeStyles } from '@material-ui/core';
-import { LectureList, ModalPopup, TimeTableMenu } from '@/components/UI/organisms';
+import { LectureList, ModalPopup, TimeTableMenu, Footer } from '@/components/UI/organisms';
 
 const useStyles = makeStyles({
   root: {
     display: 'flex',
+    flexDirection: 'column',
     justifyContent: 'center',
+    alignItems: 'center',
   },
   wrapper: {
     display: 'flex',
@@ -57,6 +59,7 @@ const MainPage = (): JSX.Element => {
             <LectureList isBasketList />
           </div>
         </div>
+        <Footer />
         <AlertSnackbar />
         <ModalPopup />
       </div>

--- a/client/src/components/pages/ReviewPage.tsx
+++ b/client/src/components/pages/ReviewPage.tsx
@@ -14,7 +14,6 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
     flexDirection: 'column',
     width: '40rem',
-    justifyContent: 'center',
     alignItems: 'center',
     minHeight: '1000px',
   },


### PR DESCRIPTION
## 📑 제목

#89 참고해주세요

![녹화_2021_05_02_17_35_50_318](https://user-images.githubusercontent.com/46101366/116807211-e1520a80-ab6c-11eb-9907-973cb4aca703.gif)

## 💬 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 강의 리뷰 클릭시 DOM 탐색에서 발생하던 버그 제거
- [x] View 작업
- [x] 내가 쓴 글일 경우 isMine Props를 통해 동작 방지
- [x] title 변경 (React App => 한표 :: 한기대 시간표 웹)
- [x] View 종류에 따른 해시태그 개수 제한 
- [x] 간단하게 Footer 제작
- [x] 그 외 기타

## 🚧 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- Strict Mode에서 findDOMNode를 권장하지 않는다는 경고를 보고 event.target을 활용하여 DOM을 탐색하는 방식에서 useRef를 통한 DOM 전달 방식으로 변경했습니다. findDOMNode가 일으킬 수 있는 문제에 대해 조사해보고 기존 코드들에 대해서도 필요하다면 리팩토링을 진행해도 좋을 것 같습니다! => [**리액트 공식 문서 findDOMNode 경고**](https://ko.reactjs.org/docs/strict-mode.html#warning-about-deprecated-finddomnode-usage)
- 심심해서 간단하게 Footer도 제작했습니다. UI나 들어갈 내용에 대해서 나중에 좀 더 이야기 해보면 좋을 듯 해요!