### PR TITLE
Button 컴포넌트 사이즈 조절이 가능하도록 수정

### DIFF
--- a/client/src/__test__/common/utils/unit.test.ts
+++ b/client/src/__test__/common/utils/unit.test.ts
@@ -1,0 +1,28 @@
+import { toPixel, toRem } from '@/common/utils/unit';
+
+describe('Unit Util Test', () => {
+  describe('toRem() test', () => {
+    test('Pixel 값을 Rem 값으로 변경할 수 있다.', () => {
+      // given
+      const pixel = 16;
+
+      // when
+      const rem = toRem(pixel);
+
+      // then
+      expect(rem).toEqual(1);
+    });
+  });
+  describe('toPixel() test', () => {
+    test('Rem 값을 Pixel 값으로 변경할 수 있다.', () => {
+      // given
+      const rem = 1;
+
+      // when
+      const pixel = toPixel(rem);
+
+      // then
+      expect(pixel).toEqual(16);
+    });
+  });
+});

--- a/client/src/common/utils/index.ts
+++ b/client/src/common/utils/index.ts
@@ -2,3 +2,4 @@ export { default as range } from './range';
 export * from './scroll';
 export { default as debounce } from './debounce';
 export * from './typeCheck';
+export * from './unit';

--- a/client/src/common/utils/unit.ts
+++ b/client/src/common/utils/unit.ts
@@ -1,0 +1,15 @@
+const DEFAULT_FONT_SIZE = 16;
+
+function toRem(pixel: number): number {
+  const rem = pixel / DEFAULT_FONT_SIZE;
+
+  return rem;
+}
+
+function toPixel(rem: number): number {
+  const pixel = rem * DEFAULT_FONT_SIZE;
+
+  return pixel;
+}
+
+export { toRem, toPixel };

--- a/client/src/components/UI/atoms/Button/Button.stories.tsx
+++ b/client/src/components/UI/atoms/Button/Button.stories.tsx
@@ -12,30 +12,15 @@ export default {
 
 const Template: Story<ButtonProps> = (args) => <Button {...args} />;
 
-export const Save = Template.bind({});
-Save.args = {
-  btnType: ButtonType.save,
+export const Primary = Template.bind({});
+Primary.args = {
+  btnType: ButtonType.primary,
   onClick: action('onClick'),
-  children: '저 장',
-};
-
-export const Share = Template.bind({});
-Share.args = {
-  btnType: ButtonType.share,
-  onClick: action('onClick'),
-  children: '공 유',
-};
-
-export const Login = Template.bind({});
-Login.args = {
-  btnType: ButtonType.login,
-  onClick: action('onClick'),
-  children: '로 그 인',
-};
-
-export const Add = Template.bind({});
-Add.args = {
-  btnType: ButtonType.add,
-  onClick: action('onClick'),
-  children: '추 가',
+  children: 'Primary',
+  style: {
+    width: 208,
+    height: 36.8,
+    borderRadius: 32,
+    fontSize: 12.8,
+  },
 };

--- a/client/src/components/UI/atoms/Button/Button.tsx
+++ b/client/src/components/UI/atoms/Button/Button.tsx
@@ -1,70 +1,47 @@
 import React from 'react';
 import { Button } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
+import { toRem } from '@/common/utils/unit';
 
 enum ButtonType {
-  save = 'save',
-  share = 'share',
-  login = 'login',
-  add = 'add',
+  primary = 'primary',
+}
+
+interface ButtonStyle {
+  width: number;
+  height: number;
+  borderRadius: number;
+  fontSize: number;
 }
 
 interface ButtonProps {
   btnType: ButtonType;
   onClick?: () => void;
   children: React.ReactChild;
+  style: ButtonStyle;
 }
 
 const useStyles = makeStyles({
-  save: {
-    width: '13rem',
-    height: '2.3rem',
-    borderRadius: '2rem',
+  primary: ({ width, height, borderRadius, fontSize }: ButtonStyle) => ({
+    width: `${toRem(width)}rem`,
+    height: `${toRem(height)}rem`,
+    borderRadius: `${toRem(borderRadius)}rem`,
     boxShadow: '0 1.5px 3px 0 rgba(0, 0, 0, 0.16)',
     '& > span': {
-      fontSize: '0.8rem',
+      fontSize: `${toRem(fontSize)}rem`,
     },
-  },
-  share: {
-    width: '13rem',
-    height: '2.3rem',
-    borderRadius: '2rem',
-    boxShadow: '0 1.5px 3px 0 rgba(0, 0, 0, 0.16)',
-    '& > span': {
-      fontSize: '0.8rem',
-    },
-  },
-  login: {
-    width: '12rem',
-    height: '2.2rem',
-    borderRadius: '4px',
-    boxShadow: '0.5px 0.5px 0.5px 0 rgba(0, 0, 0, 0.16)',
-    '& > span': {
-      fontSize: '1.2rem',
-    },
-  },
-  add: {
-    width: '3.75rem',
-    height: '2.015625rem',
-    borderRadius: '0.7rem',
-    boxShadow: '0 0.5px 1.5px 0 rgba(0, 0, 0, 0.16)',
-    '& > span': {
-      fontSize: '0.75rem',
-    },
-  },
+  }),
 });
 
-const StyledButton = ({ btnType, onClick, children }: ButtonProps): JSX.Element => {
-  const classes = useStyles();
+const StyledButton = ({ btnType, onClick, children, style }: ButtonProps): JSX.Element => {
+  const classes = useStyles({ ...style });
 
   const getClassName = () => {
     return { ...classes }[btnType];
   };
 
-  const getColor = () => (btnType === ButtonType.share ? 'secondary' : 'primary');
-
   return (
-    <Button className={getClassName()} variant="contained" color={getColor()} onClick={onClick}>
+    <Button className={getClassName()} variant="contained" color="primary" onClick={onClick}>
       {children}
     </Button>
   );

--- a/client/src/components/UI/molecules/HeaderAuthSection/HeaderAuthSectionArea.tsx
+++ b/client/src/components/UI/molecules/HeaderAuthSection/HeaderAuthSectionArea.tsx
@@ -8,6 +8,8 @@ interface HeaderAuthSectionAreaProps {
   onSignUpClick: () => void;
 }
 
+const BUTTON_STYLE_PROPS = { width: 192, height: 35.2, borderRadius: 4, fontSize: 19.2 };
+
 const useStyles = makeStyles((theme) => ({
   loginSection: {
     display: 'flex',
@@ -43,7 +45,7 @@ const HeaderAuthSectionArea = ({ onLoginClick, onSignUpClick }: HeaderAuthSectio
       <Typography className={classes.promotionText} variant="caption">
         한표를 더 편리하게 이용하세요
       </Typography>
-      <Button btnType={ButtonType.login} onClick={onLoginClick}>
+      <Button btnType={ButtonType.primary} style={BUTTON_STYLE_PROPS} onClick={onLoginClick}>
         로 그 인
       </Button>
       <div className={classes.menu}>

--- a/client/src/components/UI/molecules/LectureReviewTitle/LectureReviewTitle.stories.tsx
+++ b/client/src/components/UI/molecules/LectureReviewTitle/LectureReviewTitle.stories.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import { LectureReviewTitle } from '@/components/UI/molecules';
+import { withStoryBox } from '@/components/HOC';
+
+export default {
+  title: 'molecules/LectureReviewTitle',
+  component: LectureReviewTitle,
+  decorators: [withKnobs],
+} as Meta;
+
+const Template: Story = (args) => {
+  const LectureReviewTitleStory = withStoryBox(args, 640)(LectureReviewTitle);
+  return <LectureReviewTitleStory {...args} />;
+};
+
+export const Default = Template.bind({});

--- a/client/src/components/UI/molecules/LectureReviewTitle/LectureReviewTitle.tsx
+++ b/client/src/components/UI/molecules/LectureReviewTitle/LectureReviewTitle.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import { Typography } from '@material-ui/core';
+import { Button, ButtonType } from '@/components/UI/atoms';
+
+const BUTTON_STYLE_PROPS = { width: 160, height: 36.3, borderRadius: 16, fontSize: 20.8 };
+
+const useStyles = makeStyles({
+  titleArea: {
+    width: '100%',
+    marginTop: '1.5rem',
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+});
+
+const LectureReviewTitle = (): JSX.Element => {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.titleArea}>
+      <Typography variant="h4" color="primary">
+        강의 후기
+      </Typography>
+      <Button btnType={ButtonType.primary} style={BUTTON_STYLE_PROPS}>
+        강의 후기 쓰기
+      </Button>
+    </div>
+  );
+};
+
+export { LectureReviewTitle };

--- a/client/src/components/UI/molecules/TimeTableAddForm/TimeTableAddFormContent.tsx
+++ b/client/src/components/UI/molecules/TimeTableAddForm/TimeTableAddFormContent.tsx
@@ -14,6 +14,8 @@ const DROP_MENU_WIDTH = {
   TIME: '6.75rem',
 };
 
+const BUTTON_STYLE_PROPS = { width: 60, height: 32.25, borderRadius: 11.2, fontSize: 12 };
+
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
@@ -86,7 +88,9 @@ const TimeTableAddFormContent = ({ daySelectMenu, timeSelectMenu, onTimeTableFor
           placeholder: '이름을 입력해주세요. ex ) 근장',
         }}
       />
-      <Button btnType={ButtonType.add}>추 가</Button>
+      <Button btnType={ButtonType.primary} style={BUTTON_STYLE_PROPS}>
+        추 가
+      </Button>
     </form>
   );
 };

--- a/client/src/components/UI/molecules/index.ts
+++ b/client/src/components/UI/molecules/index.ts
@@ -28,3 +28,4 @@ export type { LectureReviewThumbsProps } from './LectureReviewThumbs/LectureRevi
 export { LectureReviewHashTags } from './LectureReviewHashTags/LectureReviewHashTags';
 export { ReviewSearchSection } from './ReviewSearchSection/ReviewSearchSection';
 export { ReviewDetailModalContent, ReviewDetailModalType } from './ReviewDetailModalContent/ReviewDetailModalContent';
+export { LectureReviewTitle } from './LectureReviewTitle/LectureReviewTitle';

--- a/client/src/components/pages/ReviewPage.tsx
+++ b/client/src/components/pages/ReviewPage.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import { Typography, Button } from '@material-ui/core';
-import { ReviewSearchSection } from '@/components/UI/molecules';
+import { ReviewSearchSection, LectureReviewTitle } from '@/components/UI/molecules';
 import { LectureReviewContainer, ModalPopup } from '@/components/UI/organisms';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles({
   root: {
     display: 'flex',
     justifyContent: 'center',
@@ -17,13 +16,6 @@ const useStyles = makeStyles((theme) => ({
     alignItems: 'center',
     minHeight: '1000px',
   },
-  titleArea: {
-    width: '100%',
-    marginTop: '1.5rem',
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
   searchArea: {
     display: 'flex',
     width: '100%',
@@ -31,15 +23,7 @@ const useStyles = makeStyles((theme) => ({
     justifyContent: 'space-between',
     alignItems: 'center',
   },
-  writeButton: {
-    width: '10rem',
-    padding: '2rem, 1rem',
-    '& > span': {
-      fontSize: '1.3rem',
-    },
-    borderRadius: '1rem',
-  },
-}));
+});
 
 const ReviewPage = (): JSX.Element => {
   const classes = useStyles();
@@ -47,14 +31,7 @@ const ReviewPage = (): JSX.Element => {
     <>
       <div className={classes.root}>
         <div className={classes.wrapper}>
-          <div className={classes.titleArea}>
-            <Typography variant="h4" color="primary">
-              강의 후기
-            </Typography>
-            <Button className={classes.writeButton} variant="contained" color="primary">
-              강의 후기 쓰기
-            </Button>
-          </div>
+          <LectureReviewTitle />
           <div className={classes.searchArea}>
             <ReviewSearchSection />
           </div>


### PR DESCRIPTION
## 📑 제목

 #80 Button 컴포넌트 사이즈 조절이 가능하도록 수정


## 💬 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] Button 컴포넌트 style props로 전달하도록 코드 수정
- [x] Button 컴포넌트 props 수정으로 인한 스토리 코드 수정
- [x] Unit Util 정의
  - 단위 변환 함수들을 모듈로 정의해놓기 위한 unit 모듈 정의
  - Pixel, Rem 단위 변환을 위한 함수 정의
  - 테스트 코드 작성
- [x] Button 컴포넌트가 사용된 코드 수정
  - TimeTableAddFormContent 컴포넌트
  - HeaderAuthSectionArea 컴포넌트
- [x] LectureReviewTitle 컴포넌트 제작 및 스토리 작성


## 🚧 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점
- 회의때 이야기한데로, Button 컴포넌트에서 외부에서 전달받아야하는 style 값들을 Props로 전달받도록 수정했습니다 :)
- Button 컴포넌트의 타입은 일단 현재 사용되고 있는 스타일만 남겨놓았습니다!  추후 다른 스타일의 버튼 사용시 그때 다시 수정할 것 같아서요!
- 강의 후기 작성 버튼을 Button 컴포넌트로 수정하면서 기존 코드에서는 페이지 단위에서 비즈니스 로직이 추가될 것 같아서 강의 리뷰 페이지에 있는 상단 영역(강의후기 타이틀, 강의 후기 작성 버튼)을 별도의 LectureReviewTitle 컴포넌트 분리하였습니다 :)