### PR TITLE
회원가입 폼 UI 변경 및 기능 구현

### DIFF
--- a/client/src/__test__/common/utils/validator.test.ts
+++ b/client/src/__test__/common/utils/validator.test.ts
@@ -1,4 +1,4 @@
-import { isEmailID, isPassword, isName } from '@/common/utils/validator';
+import { isEmailID, isPassword, isName, isNickname, isGrade, isMajor } from '@/common/utils/validator';
 
 describe('Validator Util Test', () => {
   const checkTestCases = (testFunc: Function, testCases: string[], equalValue: boolean) => {
@@ -76,6 +76,56 @@ describe('Validator Util Test', () => {
       // then
       checkTestCases(isName, validCases, true);
       checkTestCases(isName, inValidCases, false);
+    });
+  });
+
+  describe('isNickname() test', () => {
+    test('닉네임은 1자 이상이어야한다.', () => {
+      // given
+      // when
+      const validCases = ['김훈', '홍길동', '모나리자'];
+      const inValidCases = [''];
+
+      // then
+      checkTestCases(isNickname, validCases, true);
+      checkTestCases(isNickname, inValidCases, false);
+    });
+
+    test('닉네임은 영문, 한글, 숫자로 조합된 문자열만 가능하다.', () => {
+      // given
+      // when
+      const validCases = ['김훈', 'name', 'NAME', '김name', '1234', '김1234'];
+      const inValidCases = ['', '!@#$', '김!@#$#'];
+
+      // then
+      checkTestCases(isNickname, validCases, true);
+      checkTestCases(isNickname, inValidCases, false);
+    });
+  });
+
+  describe('isGrade() test', () => {
+    test('학년은 1학년 ~ 4학년까지만 존재한다.', () => {
+      // given
+      // when
+      const validCases = ['1', '2', '3', '4'];
+      const inValidCases = ['', '12', '6', '8'];
+
+      // then
+      checkTestCases(isGrade, validCases, true);
+      checkTestCases(isGrade, inValidCases, false);
+    });
+  });
+
+  describe('isMajor() test', () => {
+    test('전공은 한글로 조합된 문자열만 가능하다.', () => {
+      // given
+      // when
+      const validCases = ['컴퓨터공학부', '산업경영학부', '기계공학부'];
+      const inValidCases = ['124', '', '!@#$', '김!@#$#'];
+
+      // then
+      checkTestCases(isMajor, validCases, true);
+      checkTestCases(isMajor, inValidCases, false);
     });
   });
 });

--- a/client/src/common/styles/theme.ts
+++ b/client/src/common/styles/theme.ts
@@ -16,10 +16,10 @@ const theme = createMuiTheme({
         },
       },
       containedSecondary: {
-        backgroundColor: '#f5f5f5',
+        backgroundColor: '#f3f3f3',
         color: '#707070',
         '&:hover': {
-          backgroundColor: '#f5f5f5',
+          backgroundColor: '#f3f3f3',
         },
       },
     },

--- a/client/src/common/utils/validator.ts
+++ b/client/src/common/utils/validator.ts
@@ -10,22 +10,45 @@
 // 2자 이상
 // 한글만 가능
 
+// 한표 닉네임 제약조건
+// 1자 이상
+// 한글, 영문, 숫자 가능
+
+// 한표 닉네임 제약조건
+// 1자 이상
+// 한글, 영문, 숫자 가능
+
 const REGEX = {
   EMAIL_ID: /^[a-z0-9_][a-z0-9_]{0,11}$/,
   PASSWORD: /^(?=.*[a-zA-z])(?=.*[0-9])(?=.*[$`~!@$!%*#^?&\\(\\)\-_=+]).{8,12}$/,
   NAME: /^[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]{2,}$/,
+  NICKNAME: /^[a-zA-Z0-9ㄱ-ㅎ|ㅏ-ㅣ|가-힣]{1,}$/,
+  GRADE: /^[1-4]{1}$/,
+  MAJOR: /^[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]{1,}$/,
 };
 
-const isEmailID = (formValue: string): boolean => {
+function isEmailID(formValue: string): boolean {
   return REGEX.EMAIL_ID.test(formValue);
-};
+}
 
-const isPassword = (formValue: string): boolean => {
+function isPassword(formValue: string): boolean {
   return REGEX.PASSWORD.test(formValue);
-};
+}
 
-const isName = (formValue: string): boolean => {
+function isName(formValue: string): boolean {
   return REGEX.NAME.test(formValue);
-};
+}
 
-export { isEmailID, isPassword, isName };
+function isNickname(formValue: string): boolean {
+  return REGEX.NICKNAME.test(formValue);
+}
+
+function isGrade(formValue: string): boolean {
+  return REGEX.GRADE.test(formValue);
+}
+
+function isMajor(formValue: string): boolean {
+  return REGEX.MAJOR.test(formValue);
+}
+
+export { isEmailID, isPassword, isName, isNickname, isGrade, isMajor };

--- a/client/src/components/UI/atoms/AlertSnackbar/AlertSnackbar.tsx
+++ b/client/src/components/UI/atoms/AlertSnackbar/AlertSnackbar.tsx
@@ -8,11 +8,15 @@ import { useStores } from '@/stores';
 enum SnackbarType {
   ADD_SUCCESS = 'ADD_SUCCESS',
   DELETE_SUCCESS = 'DELETE_SUCCESS',
+  SIGNUP_SUCCESS = 'SIGNUP_SUCCESS',
+  SIGNUP_FAILED = 'SIGNUP_FAILED',
 }
 
 const SNACKBAR_MESSAGE = {
   [SnackbarType.ADD_SUCCESS]: '시간표가 추가되었습니다.',
   [SnackbarType.DELETE_SUCCESS]: '시간표가 삭제되었습니다.',
+  [SnackbarType.SIGNUP_SUCCESS]: '정상적으로 회원가입되었습니다.',
+  [SnackbarType.SIGNUP_FAILED]: '회원가입이 실패하였습니다. 다시 시도해주세요.',
 };
 
 const AlertSnackbar = (): JSX.Element => {

--- a/client/src/components/UI/atoms/Button/Button.tsx
+++ b/client/src/components/UI/atoms/Button/Button.tsx
@@ -14,16 +14,22 @@ interface ButtonStyle {
   fontSize: number;
 }
 
+interface CSSProps extends ButtonStyle {
+  fullWidth: boolean;
+}
+
 interface ButtonProps {
   btnType: ButtonType;
   onClick?: () => void;
   children: React.ReactChild;
   style: ButtonStyle;
+  color?: 'inherit' | 'primary' | 'secondary' | 'default' | undefined;
+  fullWidth?: boolean;
 }
 
 const useStyles = makeStyles({
-  primary: ({ width, height, borderRadius, fontSize }: ButtonStyle) => ({
-    width: `${toRem(width)}rem`,
+  primary: ({ width, height, borderRadius, fontSize, fullWidth }: CSSProps) => ({
+    width: fullWidth ? '100%' : `${toRem(width)}rem`,
     height: `${toRem(height)}rem`,
     borderRadius: `${toRem(borderRadius)}rem`,
     boxShadow: '0 1.5px 3px 0 rgba(0, 0, 0, 0.16)',
@@ -33,15 +39,15 @@ const useStyles = makeStyles({
   }),
 });
 
-const StyledButton = ({ btnType, onClick, children, style }: ButtonProps): JSX.Element => {
-  const classes = useStyles({ ...style });
+const StyledButton = ({ btnType, onClick, children, style, color = 'primary', fullWidth = false }: ButtonProps): JSX.Element => {
+  const classes = useStyles({ ...style, fullWidth });
 
   const getClassName = () => {
     return { ...classes }[btnType];
   };
 
   return (
-    <Button className={getClassName()} variant="contained" color="primary" onClick={onClick}>
+    <Button className={getClassName()} variant="contained" color={color} onClick={onClick}>
       {children}
     </Button>
   );

--- a/client/src/components/UI/atoms/Button/Button.tsx
+++ b/client/src/components/UI/atoms/Button/Button.tsx
@@ -25,6 +25,7 @@ interface ButtonProps {
   style: ButtonStyle;
   color?: 'inherit' | 'primary' | 'secondary' | 'default' | undefined;
   fullWidth?: boolean;
+  disabled?: boolean;
 }
 
 const useStyles = makeStyles({
@@ -39,7 +40,7 @@ const useStyles = makeStyles({
   }),
 });
 
-const StyledButton = ({ btnType, onClick, children, style, color = 'primary', fullWidth = false }: ButtonProps): JSX.Element => {
+const StyledButton = ({ btnType, onClick, children, style, color = 'primary', fullWidth = false, disabled = false }: ButtonProps): JSX.Element => {
   const classes = useStyles({ ...style, fullWidth });
 
   const getClassName = () => {
@@ -47,7 +48,7 @@ const StyledButton = ({ btnType, onClick, children, style, color = 'primary', fu
   };
 
   return (
-    <Button className={getClassName()} variant="contained" color={color} onClick={onClick}>
+    <Button className={getClassName()} variant="contained" color={color} onClick={onClick} disabled={disabled}>
       {children}
     </Button>
   );

--- a/client/src/components/UI/molecules/HeaderAuthSection/HeaderAuthSectionArea.tsx
+++ b/client/src/components/UI/molecules/HeaderAuthSection/HeaderAuthSectionArea.tsx
@@ -29,6 +29,8 @@ const useStyles = makeStyles((theme) => ({
   authText: {
     color: theme.palette.grey[600],
     '&:hover': {
+      color: theme.palette.primary.main,
+      textDecoration: 'underline',
       cursor: 'pointer',
     },
   },

--- a/client/src/components/UI/molecules/SignUpModalContent/SignUpModalContent.stories.tsx
+++ b/client/src/components/UI/molecules/SignUpModalContent/SignUpModalContent.stories.tsx
@@ -12,12 +12,32 @@ export default {
 } as Meta;
 
 const Template: Story<SignUpModalContentProps> = (args) => {
-  const SignUpModalContentStory = withStoryBox(args, 300)(SignUpModalContent);
+  const SignUpModalContentStory = withStoryBox(args, 700)(SignUpModalContent);
   return <SignUpModalContentStory />;
 };
 
 export const Default = Template.bind({});
 Default.args = {
   modalType: SignUpModalType.SIGN_UP_MODAL,
-  onModalClose: action('onClick'),
+  valid: {
+    isValidEmail: true,
+    isValidPassword: true,
+    isValidName: true,
+    isValidNickname: true,
+    isValidGrade: true,
+    isValidMajor: true,
+  },
+  selectValue: {
+    gradeValue: '',
+    majorValue: '',
+  },
+  isSignupDisabled: true,
+  onSignupBtnClick: action('onClick'),
+  onEmailChange: action('onClick'),
+  onPasswordChange: action('onClick'),
+  onNameChange: action('onClick'),
+  onNicknameChange: action('onClick'),
+  onGradeChange: action('onClick'),
+  onMajorChange: action('onClick'),
+  onMoveLoginBtnClick: action('onClick'),
 };

--- a/client/src/components/UI/molecules/SignUpModalContent/SignUpModalContent.tsx
+++ b/client/src/components/UI/molecules/SignUpModalContent/SignUpModalContent.tsx
@@ -12,6 +12,8 @@ interface SignupValid {
   isValidPassword: boolean;
   isValidName: boolean;
   isValidNickname: boolean;
+  isValidGrade: boolean;
+  isValidMajor: boolean;
 }
 
 interface SelectValue {
@@ -22,6 +24,7 @@ interface SelectValue {
 interface SignUpModalContentProps {
   valid: SignupValid;
   selectValue: SelectValue;
+  isSignupDisabled: boolean;
   onModalClose: () => void;
   onEmailChange: () => void;
   onPasswordChange: () => void;
@@ -88,18 +91,16 @@ const HELPER_TEXT = {
     SUCCESS: '사용가능한 아이디입니다.',
     CHECK: '아이디 중복체크를 진행해주세요.',
     CHECK_ERROR: '중복된 아이디입니다.',
-    ERROR: '한기대 포털 아이디는 1자리 이상 12자리 이하, 영소문자, 숫자, _ 로만 이루어져야합니다. ',
+    ERROR: '한기대 포털 아이디는 1자리 이상 12자리 이하 / 영소문자, 숫자, _ 로만 조합되어야합니다. ',
   },
   PASSWORD: {
-    DEFAULT: '비밀번호는 8자 이상 12자 이하, 영문, 특수문자, 숫자 모두 최소 1개 이상입니다.',
-    ERROR: '비밀번호는 8자 이상 12자 이하, 영문, 특수문자, 숫자 모두 최소 1개 이상이여야합니다',
+    DEFAULT: '비밀번호는 8자 이상 12자 이하 / 영문, 특수문자, 숫자 모두 최소 1개 포함해야합니다',
   },
   NAME: {
-    DEFAULT: '이름은 2자 이상, 한글입니다.',
-    ERROR: '이름은 최소 2자 이상, 한글이어야합니다.',
+    DEFAULT: '이름은 최소 2자 이상 / 한글로만 조합되어야합니다.',
   },
   NICKNAME: {
-    DEFAULT: '닉네임을 입력해주세요.',
+    DEFAULT: '닉네임은 최소 1자리 이상 / 영문, 한글, 숫자로만 조합되어야합니다.',
     SUCCESS: '사용가능한 닉네임입니다.',
     CHECK: '닉네임 중복체크를 진행해주세요.',
     CHECK_ERROR: '중복된 닉네임입니다.',
@@ -133,6 +134,7 @@ const MAJORS = [
 const SignUpModalContent = ({
   valid,
   selectValue,
+  isSignupDisabled,
   onModalClose,
   onEmailChange,
   onPasswordChange,
@@ -143,7 +145,7 @@ const SignUpModalContent = ({
   onMoveLoginBtnClick,
 }: SignUpModalContentProps): JSX.Element => {
   const classes = useStyles();
-  const { isValidEmail, isValidPassword, isValidName, isValidNickname } = valid;
+  const { isValidEmail, isValidPassword, isValidName, isValidNickname, isValidGrade, isValidMajor } = valid;
   const { gradeValue, majorValue } = selectValue;
 
   const getGradeSelectOptions = (): JSX.Element[] => {
@@ -193,7 +195,7 @@ const SignUpModalContent = ({
         </div>
         <TextField
           autoComplete="off"
-          helperText={isValidPassword ? HELPER_TEXT.PASSWORD.DEFAULT : HELPER_TEXT.PASSWORD.ERROR}
+          helperText={HELPER_TEXT.PASSWORD.DEFAULT}
           error={!isValidPassword}
           margin="dense"
           id="password"
@@ -206,7 +208,7 @@ const SignUpModalContent = ({
         />
         <TextField
           autoComplete="off"
-          helperText={isValidName ? HELPER_TEXT.NAME.DEFAULT : HELPER_TEXT.NAME.ERROR}
+          helperText={HELPER_TEXT.NAME.DEFAULT}
           error={!isValidName}
           margin="dense"
           id="name"
@@ -221,6 +223,7 @@ const SignUpModalContent = ({
           <TextField
             autoComplete="off"
             helperText={HELPER_TEXT.NICKNAME.DEFAULT}
+            error={!isValidNickname}
             margin="dense"
             id="nickname"
             label="닉네임"
@@ -237,6 +240,7 @@ const SignUpModalContent = ({
         <div className={classes.selectArea}>
           <TextField
             helperText={HELPER_TEXT.GRADE.DEFAULT}
+            error={!isValidGrade}
             select
             label="학년"
             margin="dense"
@@ -249,6 +253,7 @@ const SignUpModalContent = ({
           </TextField>
           <TextField
             helperText={HELPER_TEXT.MAJOR.DEFAULT}
+            error={!isValidMajor}
             select
             label="전공"
             margin="dense"
@@ -262,7 +267,7 @@ const SignUpModalContent = ({
         </div>
       </DialogContent>
       <DialogActions className={classes.dialogActionRoot}>
-        <Button btnType={ButtonType.primary} onClick={onModalClose} style={SIGNUP_BUTTON_STYLE_PROPS} fullWidth>
+        <Button btnType={ButtonType.primary} onClick={onModalClose} style={SIGNUP_BUTTON_STYLE_PROPS} disabled={isSignupDisabled} fullWidth>
           회원가입
         </Button>
         <div className={classes.linkTextArea}>

--- a/client/src/components/UI/molecules/SignUpModalContent/SignUpModalContent.tsx
+++ b/client/src/components/UI/molecules/SignUpModalContent/SignUpModalContent.tsx
@@ -29,6 +29,7 @@ interface SignUpModalContentProps {
   onNicknameChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onGradeChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onMajorChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onMoveLoginBtnClick: () => void;
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -139,6 +140,7 @@ const SignUpModalContent = ({
   onNicknameChange,
   onGradeChange,
   onMajorChange,
+  onMoveLoginBtnClick,
 }: SignUpModalContentProps): JSX.Element => {
   const classes = useStyles();
   const { isValidEmail, isValidPassword, isValidName, isValidNickname } = valid;
@@ -264,7 +266,7 @@ const SignUpModalContent = ({
           회원가입
         </Button>
         <div className={classes.linkTextArea}>
-          <Typography className={classes.linkText} variant="caption">
+          <Typography className={classes.linkText} variant="caption" onClick={onMoveLoginBtnClick}>
             이미 가입하셨나요? 로그인하기
           </Typography>
         </div>

--- a/client/src/components/UI/molecules/SignUpModalContent/SignUpModalContent.tsx
+++ b/client/src/components/UI/molecules/SignUpModalContent/SignUpModalContent.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
-import { Button, DialogTitle, DialogContent, DialogActions, TextField } from '@material-ui/core';
+import React, { useState } from 'react';
+import { DialogTitle, DialogContent, DialogActions, TextField, Typography, MenuItem } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
+import { Button, ButtonType } from '@/components/UI/atoms';
 
 enum SignUpModalType {
   SIGN_UP_MODAL = 'SIGN_UP_MODAL',
@@ -10,15 +11,24 @@ interface SignupValid {
   isValidEmail: boolean;
   isValidPassword: boolean;
   isValidName: boolean;
+  isValidNickname: boolean;
+}
+
+interface SelectValue {
+  gradeValue: string;
+  majorValue: string;
 }
 
 interface SignUpModalContentProps {
   valid: SignupValid;
+  selectValue: SelectValue;
   onModalClose: () => void;
   onEmailChange: () => void;
   onPasswordChange: () => void;
   onNameChange: () => void;
   onNicknameChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onGradeChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onMajorChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -28,33 +38,131 @@ const useStyles = makeStyles((theme) => ({
     fontSize: '1.7rem',
     color: theme.palette.primary.main,
   },
+  checkArea: {
+    display: 'flex',
+    '& > *': {
+      marginRight: '8px',
+    },
+    '& > *:not(:first-child)': {
+      marginTop: '7px',
+    },
+  },
+  checkButton: {
+    marginTop: '7px',
+  },
+  selectArea: {
+    display: 'flex',
+    '& > *': {
+      marginRight: '8px',
+    },
+  },
+  dialogActionRoot: {
+    display: 'flex',
+    flexDirection: 'column',
+
+    '&.MuiDialogActions-root': {
+      padding: '16px 24px',
+    },
+  },
+  linkTextArea: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    width: '100%',
+    paddingTop: '16px',
+    margin: '0 !important',
+  },
+  linkText: {
+    color: theme.palette.grey[600],
+    '&:hover': {
+      color: theme.palette.primary.main,
+      textDecoration: 'underline',
+      cursor: 'pointer',
+    },
+  },
 }));
 
 const HELPER_TEXT = {
   EMAIL: {
-    DEFAULT: 'koreatech.ac.kr은 빼고 입력해주세요.',
-    ERROR: 'Email 형식이 적합하지 않습니다.',
+    DEFAULT: '아이디는 한기대 포털 아이디입니다. @koreatech.ac.kr은 빼고 입력해주세요.',
+    SUCCESS: '사용가능한 아이디입니다.',
+    CHECK: '아이디 중복체크를 진행해주세요.',
+    CHECK_ERROR: '중복된 아이디입니다.',
+    ERROR: '한기대 포털 아이디는 1자리 이상 12자리 이하, 영소문자, 숫자, _ 로만 이루어져야합니다. ',
   },
   PASSWORD: {
-    DEFAULT: 'Password는 8자 이상 12자 이하로 입력해주세요.',
-    ERROR: 'Password 형식이 적합하지 않습니다.',
+    DEFAULT: '비밀번호는 8자 이상 12자 이하, 영문, 특수문자, 숫자 모두 최소 1개 이상입니다.',
+    ERROR: '비밀번호는 8자 이상 12자 이하, 영문, 특수문자, 숫자 모두 최소 1개 이상이여야합니다',
   },
   NAME: {
-    DEFAULT: '이름은 2자 이상 입력해주세요.',
-    ERROR: '이름 형식이 적합하지 않습니다.',
+    DEFAULT: '이름은 2자 이상, 한글입니다.',
+    ERROR: '이름은 최소 2자 이상, 한글이어야합니다.',
+  },
+  NICKNAME: {
+    DEFAULT: '닉네임을 입력해주세요.',
+    SUCCESS: '사용가능한 닉네임입니다.',
+    CHECK: '닉네임 중복체크를 진행해주세요.',
+    CHECK_ERROR: '중복된 닉네임입니다.',
+  },
+  GRADE: {
+    DEFAULT: '학년을 선택해주세요.',
+  },
+  MAJOR: {
+    DEFAULT: '전공을 선택해주세요.',
   },
 };
 
+const SIGNUP_BUTTON_STYLE_PROPS = { width: 192, height: 35.2, borderRadius: 4, fontSize: 16 };
+const CHECK_BUTTON_STYLE_PROPS = { width: 96, height: 40, borderRadius: 4, fontSize: 13 };
+
+const GRADES = [1, 2, 3, 4];
+
+const MAJORS = [
+  '기계공학부',
+  '메카트로닉스공학부',
+  '전기전자통신공학부',
+  '컴퓨터공학부',
+  '디자인건축공학부',
+  '에너지신소재화학공학부',
+  '산업경영학부',
+  '교양학부',
+  'HRD학과',
+  '융합학과',
+];
+
 const SignUpModalContent = ({
   valid,
+  selectValue,
   onModalClose,
   onEmailChange,
   onPasswordChange,
   onNameChange,
   onNicknameChange,
+  onGradeChange,
+  onMajorChange,
 }: SignUpModalContentProps): JSX.Element => {
   const classes = useStyles();
-  const { isValidEmail, isValidPassword, isValidName } = valid;
+  const { isValidEmail, isValidPassword, isValidName, isValidNickname } = valid;
+  const { gradeValue, majorValue } = selectValue;
+
+  const getGradeSelectOptions = (): JSX.Element[] => {
+    const gradeSelectOptions = GRADES.map((grade) => (
+      <MenuItem key={grade} value={grade}>
+        {grade}
+      </MenuItem>
+    ));
+
+    return gradeSelectOptions;
+  };
+
+  const getMajorSelectOptions = (): JSX.Element[] => {
+    const majorSelectOptions = MAJORS.map((major) => (
+      <MenuItem key={major} value={major}>
+        {major}
+      </MenuItem>
+    ));
+
+    return majorSelectOptions;
+  };
 
   return (
     <>
@@ -62,18 +170,25 @@ const SignUpModalContent = ({
         한표 회원가입
       </DialogTitle>
       <DialogContent>
-        <TextField
-          autoComplete="off"
-          helperText={isValidEmail ? HELPER_TEXT.EMAIL.DEFAULT : HELPER_TEXT.EMAIL.ERROR}
-          error={!isValidEmail}
-          autoFocus
-          margin="dense"
-          id="id"
-          label="아이디"
-          type="email"
-          fullWidth
-          onChange={onEmailChange}
-        />
+        <div className={classes.checkArea}>
+          <TextField
+            autoComplete="off"
+            helperText={isValidEmail ? HELPER_TEXT.EMAIL.DEFAULT : HELPER_TEXT.EMAIL.ERROR}
+            error={!isValidEmail}
+            autoFocus
+            margin="dense"
+            id="id"
+            label="아이디"
+            type="email"
+            variant="outlined"
+            required
+            fullWidth
+            onChange={onEmailChange}
+          />
+          <Button btnType={ButtonType.primary} color="secondary" style={CHECK_BUTTON_STYLE_PROPS}>
+            중복체크
+          </Button>
+        </div>
         <TextField
           autoComplete="off"
           helperText={isValidPassword ? HELPER_TEXT.PASSWORD.DEFAULT : HELPER_TEXT.PASSWORD.ERROR}
@@ -82,6 +197,8 @@ const SignUpModalContent = ({
           id="password"
           label="비밀번호"
           type="password"
+          variant="outlined"
+          required
           fullWidth
           onChange={onPasswordChange}
         />
@@ -93,15 +210,64 @@ const SignUpModalContent = ({
           id="name"
           label="이름"
           type="text"
+          variant="outlined"
+          required
           fullWidth
           onChange={onNameChange}
         />
-        <TextField autoComplete="off" margin="dense" id="nickname" label="닉네임" type="text" fullWidth onChange={onNicknameChange} />
+        <div className={classes.checkArea}>
+          <TextField
+            autoComplete="off"
+            helperText={HELPER_TEXT.NICKNAME.DEFAULT}
+            margin="dense"
+            id="nickname"
+            label="닉네임"
+            type="text"
+            variant="outlined"
+            required
+            fullWidth
+            onChange={onNicknameChange}
+          />
+          <Button btnType={ButtonType.primary} color="secondary" style={CHECK_BUTTON_STYLE_PROPS}>
+            중복체크
+          </Button>
+        </div>
+        <div className={classes.selectArea}>
+          <TextField
+            helperText={HELPER_TEXT.GRADE.DEFAULT}
+            select
+            label="학년"
+            margin="dense"
+            variant="outlined"
+            value={gradeValue}
+            required
+            fullWidth
+            onChange={onGradeChange}>
+            {getGradeSelectOptions()}
+          </TextField>
+          <TextField
+            helperText={HELPER_TEXT.MAJOR.DEFAULT}
+            select
+            label="전공"
+            margin="dense"
+            variant="outlined"
+            value={majorValue}
+            required
+            fullWidth
+            onChange={onMajorChange}>
+            {getMajorSelectOptions()}
+          </TextField>
+        </div>
       </DialogContent>
-      <DialogActions>
-        <Button onClick={onModalClose} color="primary">
+      <DialogActions className={classes.dialogActionRoot}>
+        <Button btnType={ButtonType.primary} onClick={onModalClose} style={SIGNUP_BUTTON_STYLE_PROPS} fullWidth>
           회원가입
         </Button>
+        <div className={classes.linkTextArea}>
+          <Typography className={classes.linkText} variant="caption">
+            이미 가입하셨나요? 로그인하기
+          </Typography>
+        </div>
       </DialogActions>
     </>
   );

--- a/client/src/components/UI/molecules/SignUpModalContent/SignUpModalContent.tsx
+++ b/client/src/components/UI/molecules/SignUpModalContent/SignUpModalContent.tsx
@@ -25,7 +25,7 @@ interface SignUpModalContentProps {
   valid: SignupValid;
   selectValue: SelectValue;
   isSignupDisabled: boolean;
-  onModalClose: () => void;
+  onSignupBtnClick: () => void;
   onEmailChange: () => void;
   onPasswordChange: () => void;
   onNameChange: () => void;
@@ -135,7 +135,7 @@ const SignUpModalContent = ({
   valid,
   selectValue,
   isSignupDisabled,
-  onModalClose,
+  onSignupBtnClick,
   onEmailChange,
   onPasswordChange,
   onNameChange,
@@ -267,7 +267,7 @@ const SignUpModalContent = ({
         </div>
       </DialogContent>
       <DialogActions className={classes.dialogActionRoot}>
-        <Button btnType={ButtonType.primary} onClick={onModalClose} style={SIGNUP_BUTTON_STYLE_PROPS} disabled={isSignupDisabled} fullWidth>
+        <Button btnType={ButtonType.primary} onClick={onSignupBtnClick} style={SIGNUP_BUTTON_STYLE_PROPS} disabled={isSignupDisabled} fullWidth>
           회원가입
         </Button>
         <div className={classes.linkTextArea}>

--- a/client/src/components/UI/molecules/SignUpModalContent/SignUpModalContent.tsx
+++ b/client/src/components/UI/molecules/SignUpModalContent/SignUpModalContent.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { DialogTitle, DialogContent, DialogActions, TextField, Typography, MenuItem } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import { Button, ButtonType } from '@/components/UI/atoms';

--- a/client/src/components/UI/molecules/SignUpModalContent/SignUpModalContent.tsx
+++ b/client/src/components/UI/molecules/SignUpModalContent/SignUpModalContent.tsx
@@ -45,19 +45,19 @@ const useStyles = makeStyles((theme) => ({
   checkArea: {
     display: 'flex',
     '& > *': {
-      marginRight: '8px',
+      marginRight: '0.5rem',
     },
     '& > *:not(:first-child)': {
-      marginTop: '7px',
+      marginTop: '0.4375rem',
     },
   },
   checkButton: {
-    marginTop: '7px',
+    marginTop: '0.4375rem',
   },
   selectArea: {
     display: 'flex',
     '& > *': {
-      marginRight: '8px',
+      marginRight: '0.5rem',
     },
   },
   dialogActionRoot: {
@@ -65,14 +65,14 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: 'column',
 
     '&.MuiDialogActions-root': {
-      padding: '16px 24px',
+      padding: '1rem 1.5rem',
     },
   },
   linkTextArea: {
     display: 'flex',
     justifyContent: 'flex-end',
     width: '100%',
-    paddingTop: '16px',
+    paddingTop: '1rem',
     margin: '0 !important',
   },
   linkText: {

--- a/client/src/components/UI/organisms/ModalPopup/SignUpModalPopup.tsx
+++ b/client/src/components/UI/organisms/ModalPopup/SignUpModalPopup.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { SnackbarType } from '@/components/UI/atoms';
 import { ModalPopupArea, SignUpModalContent } from '@/components/UI/molecules';
 import { modalTypes } from '@/components/UI/organisms';
 import { isEmailID, isPassword, isName, isNickname, isGrade, isMajor } from '@/common/utils/validator';
@@ -27,10 +28,17 @@ const SignUpModalPopup = ({ modalOpen, onModalAreaClose }: SignUpModalPopupProps
   const [isValidGrade, setIsValidGrade] = useState(true);
   const [isValidMajor, setIsValidMajor] = useState(true);
 
-  const { modalStore } = useStores();
+  const { modalStore, snackbarStore } = useStores();
   const [signup] = useMutation(SIGN_UP, {
     onCompleted: () => {
+      snackbarStore.setSnackbarType(SnackbarType.SIGNUP_SUCCESS);
+      snackbarStore.setSnackbarState(true);
+
       modalStore.changeModalState(modalTypes.LOGIN_MODAL, true);
+    },
+    onError: () => {
+      snackbarStore.setSnackbarType(SnackbarType.SIGNUP_FAILED);
+      snackbarStore.setSnackbarState(true);
     },
   });
 

--- a/client/src/components/UI/organisms/ModalPopup/SignUpModalPopup.tsx
+++ b/client/src/components/UI/organisms/ModalPopup/SignUpModalPopup.tsx
@@ -17,9 +17,14 @@ const SignUpModalPopup = ({ modalOpen, onModalAreaClose }: SignUpModalPopupProps
   const [password, setPassword] = useState('');
   const [name, setName] = useState('');
   const [nickname, setNickname] = useState('');
+  const [gradeValue, setGradeValue] = useState('');
+  const [majorValue, setMajorValue] = useState('');
+
   const [isValidEmail, setIsValidEmail] = useState(true);
   const [isValidPassword, setIsValidPassword] = useState(true);
   const [isValidName, setIsValidName] = useState(true);
+  const [isValidNickname, setIsValidNickname] = useState(true);
+
   const { modalStore } = useStores();
   const [signup] = useMutation(SIGN_UP, {
     onCompleted: () => {
@@ -54,6 +59,18 @@ const SignUpModalPopup = ({ modalOpen, onModalAreaClose }: SignUpModalPopupProps
     setNickname(nickNameValue);
   };
 
+  const onGradeChangeListener = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { value: gradeSelectValue } = event.target;
+
+    setGradeValue(gradeSelectValue);
+  };
+
+  const onMajorChangeListener = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { value: majorSelectValue } = event.target;
+
+    setMajorValue(majorSelectValue);
+  };
+
   const isValidFormDatas = (): boolean => {
     return isValidEmail && isValidPassword && isValidName;
   };
@@ -68,12 +85,15 @@ const SignUpModalPopup = ({ modalOpen, onModalAreaClose }: SignUpModalPopupProps
   return (
     <ModalPopupArea modalOpen={modalOpen} onModalClose={onModalAreaClose}>
       <SignUpModalContent
-        valid={{ isValidEmail, isValidPassword, isValidName }}
+        valid={{ isValidEmail, isValidPassword, isValidName, isValidNickname }}
+        selectValue={{ gradeValue, majorValue }}
         onModalClose={onSignUpBtnClickListener}
         onEmailChange={onDebouncedEmailChangeListener}
         onPasswordChange={onDebouncedPasswordChangeListener}
         onNameChange={onDebouncedNameChangeListener}
         onNicknameChange={onNicknameChangeListener}
+        onGradeChange={onGradeChangeListener}
+        onMajorChange={onMajorChangeListener}
       />
     </ModalPopupArea>
   );

--- a/client/src/components/UI/organisms/ModalPopup/SignUpModalPopup.tsx
+++ b/client/src/components/UI/organisms/ModalPopup/SignUpModalPopup.tsx
@@ -94,7 +94,7 @@ const SignUpModalPopup = ({ modalOpen, onModalAreaClose }: SignUpModalPopupProps
     return isValidEmail && isValidPassword && isValidName && isValidNickname && isValidGrade && isValidMajor;
   };
 
-  const checkAndSetSignupDisabled = (): boolean => {
+  const checkSignupDisabled = (): boolean => {
     const isExistEmptyFormDatas = checkEmptyFormDatas();
     const isValidDatas = checkIsValidDatas();
 
@@ -106,7 +106,7 @@ const SignUpModalPopup = ({ modalOpen, onModalAreaClose }: SignUpModalPopupProps
       <SignUpModalContent
         valid={{ isValidEmail, isValidPassword, isValidName, isValidNickname, isValidGrade, isValidMajor }}
         selectValue={{ gradeValue: grade, majorValue: major }}
-        isSignupDisabled={checkAndSetSignupDisabled()}
+        isSignupDisabled={checkSignupDisabled()}
         onModalClose={onSignUpBtnClickListener}
         onEmailChange={onDebouncedEmailChangeListener}
         onPasswordChange={onDebouncedPasswordChangeListener}

--- a/client/src/components/UI/organisms/ModalPopup/SignUpModalPopup.tsx
+++ b/client/src/components/UI/organisms/ModalPopup/SignUpModalPopup.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { ModalPopupArea, SignUpModalContent } from '@/components/UI/molecules';
 import { modalTypes } from '@/components/UI/organisms';
-import { isEmailID, isPassword, isName } from '@/common/utils/validator';
+import { isEmailID, isPassword, isName, isNickname, isGrade, isMajor } from '@/common/utils/validator';
 import { debounce } from '@/common/utils';
 import { useMutation } from '@apollo/client';
 import { SIGN_UP } from '@/queries';
@@ -17,13 +17,15 @@ const SignUpModalPopup = ({ modalOpen, onModalAreaClose }: SignUpModalPopupProps
   const [password, setPassword] = useState('');
   const [name, setName] = useState('');
   const [nickname, setNickname] = useState('');
-  const [gradeValue, setGradeValue] = useState('');
-  const [majorValue, setMajorValue] = useState('');
+  const [grade, setGrade] = useState('');
+  const [major, setMajor] = useState('');
 
   const [isValidEmail, setIsValidEmail] = useState(true);
   const [isValidPassword, setIsValidPassword] = useState(true);
   const [isValidName, setIsValidName] = useState(true);
   const [isValidNickname, setIsValidNickname] = useState(true);
+  const [isValidGrade, setIsValidGrade] = useState(true);
+  const [isValidMajor, setIsValidMajor] = useState(true);
 
   const { modalStore } = useStores();
   const [signup] = useMutation(SIGN_UP, {
@@ -53,44 +55,58 @@ const SignUpModalPopup = ({ modalOpen, onModalAreaClose }: SignUpModalPopupProps
     setIsValidName(isName(nameValue));
   }, 500);
 
-  const onNicknameChangeListener = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const onNicknameChangeListener = debounce((e: React.ChangeEvent<HTMLInputElement>) => {
     const { value: nickNameValue } = e.target;
 
     setNickname(nickNameValue);
-  };
+    setIsValidNickname(isNickname(nickNameValue));
+  }, 500);
 
-  const onGradeChangeListener = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const { value: gradeSelectValue } = event.target;
+  const onGradeChangeListener = debounce((event: React.ChangeEvent<HTMLInputElement>) => {
+    const { value: gradeValue } = event.target;
 
-    setGradeValue(gradeSelectValue);
-  };
+    setGrade(gradeValue);
+    setIsValidGrade(isGrade(gradeValue));
+  }, 500);
 
-  const onMajorChangeListener = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const { value: majorSelectValue } = event.target;
+  const onMajorChangeListener = debounce((event: React.ChangeEvent<HTMLInputElement>) => {
+    const { value: majorValue } = event.target;
 
-    setMajorValue(majorSelectValue);
-  };
-
-  const isValidFormDatas = (): boolean => {
-    return isValidEmail && isValidPassword && isValidName;
-  };
-
-  const onSignUpBtnClickListener = () => {
-    if (!isValidFormDatas()) alert('회원가입 형식이 맞지 않습니다!');
-    signup({
-      variables: { email, password, name, nickname, grade: 1, major: 'CSE' },
-    });
-  };
+    setMajor(majorValue);
+    setIsValidMajor(isMajor(majorValue));
+  }, 500);
 
   const onMoveLoginBtnClickListener = () => {
     modalStore.changeModalState(modalTypes.LOGIN_MODAL, true);
   };
 
+  const onSignUpBtnClickListener = () => {
+    signup({
+      variables: { email, password, name, nickname, grade, major },
+    });
+  };
+
+  const checkEmptyFormDatas = (): boolean => {
+    return !(email && password && name && nickname && grade && major);
+  };
+
+  const checkIsValidDatas = (): boolean => {
+    return isValidEmail && isValidPassword && isValidName && isValidNickname && isValidGrade && isValidMajor;
+  };
+
+  const checkAndSetSignupDisabled = (): boolean => {
+    const isExistEmptyFormDatas = checkEmptyFormDatas();
+    const isValidDatas = checkIsValidDatas();
+
+    return !(!isExistEmptyFormDatas && isValidDatas);
+  };
+
   return (
     <ModalPopupArea modalOpen={modalOpen} onModalClose={onModalAreaClose}>
       <SignUpModalContent
-        valid={{ isValidEmail, isValidPassword, isValidName, isValidNickname }}
-        selectValue={{ gradeValue, majorValue }}
+        valid={{ isValidEmail, isValidPassword, isValidName, isValidNickname, isValidGrade, isValidMajor }}
+        selectValue={{ gradeValue: grade, majorValue: major }}
+        isSignupDisabled={checkAndSetSignupDisabled()}
         onModalClose={onSignUpBtnClickListener}
         onEmailChange={onDebouncedEmailChangeListener}
         onPasswordChange={onDebouncedPasswordChangeListener}

--- a/client/src/components/UI/organisms/ModalPopup/SignUpModalPopup.tsx
+++ b/client/src/components/UI/organisms/ModalPopup/SignUpModalPopup.tsx
@@ -82,6 +82,10 @@ const SignUpModalPopup = ({ modalOpen, onModalAreaClose }: SignUpModalPopupProps
     });
   };
 
+  const onMoveLoginBtnClickListener = () => {
+    modalStore.changeModalState(modalTypes.LOGIN_MODAL, true);
+  };
+
   return (
     <ModalPopupArea modalOpen={modalOpen} onModalClose={onModalAreaClose}>
       <SignUpModalContent
@@ -94,6 +98,7 @@ const SignUpModalPopup = ({ modalOpen, onModalAreaClose }: SignUpModalPopupProps
         onNicknameChange={onNicknameChangeListener}
         onGradeChange={onGradeChangeListener}
         onMajorChange={onMajorChangeListener}
+        onMoveLoginBtnClick={onMoveLoginBtnClickListener}
       />
     </ModalPopupArea>
   );

--- a/client/src/components/UI/organisms/ModalPopup/SignUpModalPopup.tsx
+++ b/client/src/components/UI/organisms/ModalPopup/SignUpModalPopup.tsx
@@ -86,6 +86,34 @@ const SignUpModalPopup = ({ modalOpen, onModalAreaClose }: SignUpModalPopupProps
     });
   };
 
+  const resetFormDatas = () => {
+    setEmail('');
+    setPassword('');
+    setName('');
+    setNickname('');
+    setGrade('');
+    setMajor('');
+  };
+
+  const resetValidDatas = () => {
+    setIsValidEmail(true);
+    setIsValidPassword(true);
+    setIsValidName(true);
+    setIsValidNickname(true);
+    setIsValidGrade(true);
+    setIsValidMajor(true);
+  };
+
+  const resetSignupForm = () => {
+    resetFormDatas();
+    resetValidDatas();
+  };
+
+  const onSignupModalCloseListener = () => {
+    resetSignupForm();
+    onModalAreaClose();
+  };
+
   const checkEmptyFormDatas = (): boolean => {
     return !(email && password && name && nickname && grade && major);
   };
@@ -102,12 +130,12 @@ const SignUpModalPopup = ({ modalOpen, onModalAreaClose }: SignUpModalPopupProps
   };
 
   return (
-    <ModalPopupArea modalOpen={modalOpen} onModalClose={onModalAreaClose}>
+    <ModalPopupArea modalOpen={modalOpen} onModalClose={onSignupModalCloseListener}>
       <SignUpModalContent
         valid={{ isValidEmail, isValidPassword, isValidName, isValidNickname, isValidGrade, isValidMajor }}
         selectValue={{ gradeValue: grade, majorValue: major }}
         isSignupDisabled={checkSignupDisabled()}
-        onModalClose={onSignUpBtnClickListener}
+        onSignupBtnClick={onSignUpBtnClickListener}
         onEmailChange={onDebouncedEmailChangeListener}
         onPasswordChange={onDebouncedPasswordChangeListener}
         onNameChange={onDebouncedNameChangeListener}

--- a/client/src/stores/SnackbarStore.ts
+++ b/client/src/stores/SnackbarStore.ts
@@ -20,7 +20,7 @@ class SnackbarStore {
     };
   }
 
-  setSnackbarState(newSnackbarState: boolean) {
+  setSnackbarState(newSnackbarState: boolean): void {
     const { snackbarState } = this.state;
 
     if (snackbarState() === newSnackbarState) return;
@@ -28,7 +28,7 @@ class SnackbarStore {
     snackbarState(newSnackbarState);
   }
 
-  setSnackbarType(newSnackbarType: SnackbarType) {
+  setSnackbarType(newSnackbarType: SnackbarType): void {
     const { snackbarType } = this.state;
 
     if (snackbarType() === newSnackbarType) return;


### PR DESCRIPTION
## 📑 제목

#76 #96 회원가입 폼 UI 변경 및 기능 구현


## 💬 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 회원가입 폼 모달창 UI 변경 작업
  - 전체 폼 디자인 변경 (input요소 스타일, 회원가입 버튼 비활성화)
  - 학년, 전공 선택 요소 추가
  - 아이디, 닉네임 중복체크 버튼 추가
  - 로그인 폼 모달창 이동 링크 추가 (이미 가입하셨나요? 로그인하기 링크)
  - helperText 명확하게 변경
![image](https://user-images.githubusercontent.com/32856129/117607002-0a3e5500-b196-11eb-88ce-3cdfbcacb975.png)

- [x] 회원가입 기능 구현
  - 회원가입 폼 데이터가 빈 값이거나 유효성 검사를 통과하지 못하면 회원가입 버튼 비활성화
  - 회원가입 성공 시 회원가입 성공 AlertSnackbar 메시지 표시 및 로그인 폼으로 이동
  - 회원가입 실패 시 회원가입 실패 AlertSnackbar 메시지 표시
![ezgif com-gif-maker (39)](https://user-images.githubusercontent.com/32856129/117608131-6ace9180-b198-11eb-83e4-38accd0b368a.gif)

- [x] 기타 작업사항
  - Validator Util 닉네임, 학년, 전공, 유효성 검사 추가 및 테스트 코드 작성
  - Button 컴포넌트 커스텀을 위해  fullWidth(width=100%), color(Theme 색상 지정), disabled(활성화 여부) props 추가
  - AlertSnackbar 회원가입 성공, 실패 메세지 추가


## 🚧 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 아이디, 닉네임 중복체크 로직은 미구현입니다. 서버 API가 완성되면 추가할 예정입니다 :)