### PR TITLE
로그인 폼 UI 변경 및 로그인 기능 구현 

### DIFF
--- a/client/src/common/hooks/index.ts
+++ b/client/src/common/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useFetchAsync } from './useFetchAsync';

--- a/client/src/common/hooks/useFetchAsync.ts
+++ b/client/src/common/hooks/useFetchAsync.ts
@@ -1,0 +1,45 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { useState } from 'react';
+
+interface FetchCallback {
+  onCompleted?: Function;
+  onError?: Function;
+}
+
+const INIT_REQUEST_OPTION = {
+  method: 'GET',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+};
+
+function useFetchAsync(url: string, option: RequestInit = INIT_REQUEST_OPTION, callback?: FetchCallback): [(bodyData: {}) => Promise<void>, boolean] {
+  const [loading, setLoading] = useState(true);
+
+  const executeCallback = (response: Response, data: any) => {
+    if (!callback) return;
+
+    const { onCompleted, onError } = callback;
+
+    if (response.ok && onCompleted) {
+      onCompleted(data);
+      return;
+    }
+
+    if (onError) {
+      onError();
+    }
+  };
+
+  const fetchData = async (bodyData: {}) => {
+    const response = await fetch(url, { ...option, body: JSON.stringify({ ...bodyData }) });
+    const data = response.bodyUsed ? await response.json() : null;
+
+    executeCallback(response, data);
+    setLoading(false);
+  };
+
+  return [fetchData, loading];
+}
+
+export default useFetchAsync;

--- a/client/src/components/UI/atoms/AlertSnackbar/AlertSnackbar.tsx
+++ b/client/src/components/UI/atoms/AlertSnackbar/AlertSnackbar.tsx
@@ -10,6 +10,8 @@ enum SnackbarType {
   DELETE_SUCCESS = 'DELETE_SUCCESS',
   SIGNUP_SUCCESS = 'SIGNUP_SUCCESS',
   SIGNUP_FAILED = 'SIGNUP_FAILED',
+  LOGIN_SUCCESS = 'LOGIN_SUCCESS',
+  LOGIN_FAILED = 'LOGIN_FAILED',
 }
 
 const SNACKBAR_MESSAGE = {
@@ -17,6 +19,8 @@ const SNACKBAR_MESSAGE = {
   [SnackbarType.DELETE_SUCCESS]: '시간표가 삭제되었습니다.',
   [SnackbarType.SIGNUP_SUCCESS]: '정상적으로 회원가입되었습니다.',
   [SnackbarType.SIGNUP_FAILED]: '회원가입이 실패하였습니다. 다시 시도해주세요.',
+  [SnackbarType.LOGIN_SUCCESS]: '정상적으로 로그인되었습니다.',
+  [SnackbarType.LOGIN_FAILED]: '로그인이 실패하였습니다. 다시 시도해주세요.',
 };
 
 const AlertSnackbar = (): JSX.Element => {

--- a/client/src/components/UI/molecules/LoginModalContent/LoginModalContent.stories.tsx
+++ b/client/src/components/UI/molecules/LoginModalContent/LoginModalContent.stories.tsx
@@ -3,7 +3,7 @@ import { withKnobs } from '@storybook/addon-knobs';
 import { Story, Meta } from '@storybook/react/types-6-0';
 import { action } from '@storybook/addon-actions';
 import { withStoryBox } from '@/components/HOC';
-import { LoginModalContent, LoginModalType, LoginModalContentProps } from './LoginModalContent';
+import { LoginModalContent, LoginModalContentProps } from './LoginModalContent';
 
 export default {
   title: 'molecules/LoginModalContent',
@@ -18,6 +18,9 @@ const Template: Story<LoginModalContentProps> = (args) => {
 
 export const Default = Template.bind({});
 Default.args = {
-  modalType: LoginModalType.LOGIN_MODAL,
-  onModalClose: action('onClick'),
+  isLoginDisabled: true,
+  onLoginBtnClick: action('onClick'),
+  onEmailChange: action('onChange'),
+  onPasswordChange: action('onChange'),
+  onMovesignUpBtnClick: action('onClick'),
 };

--- a/client/src/components/UI/molecules/LoginModalContent/LoginModalContent.tsx
+++ b/client/src/components/UI/molecules/LoginModalContent/LoginModalContent.tsx
@@ -1,16 +1,18 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { DialogTitle, DialogContent, DialogActions, TextField, Typography } from '@material-ui/core';
 import { Button, ButtonType } from '@/components/UI/atoms';
 import { makeStyles } from '@material-ui/core/styles';
-import { debounce } from '@/common/utils';
-import { isEmailID, isPassword } from '@/common/utils/validator';
 
 enum LoginModalType {
   LOGIN_MODAL = 'LOGIN_MODAL',
 }
 
 interface LoginModalContentProps {
-  onModalClose: () => void;
+  isLoginDisabled: boolean;
+  onLoginBtnClick: () => void;
+  onEmailChange: () => void;
+  onPasswordChange: () => void;
+  onMovesignUpBtnClick: () => void;
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -52,26 +54,14 @@ const useStyles = makeStyles((theme) => ({
 
 const LOGIN_BUTTON_STYLE_PROPS = { width: 192, height: 35.2, borderRadius: 4, fontSize: 16 };
 
-const LoginModalContent = ({ onModalClose }: LoginModalContentProps): JSX.Element => {
+const LoginModalContent = ({
+  isLoginDisabled,
+  onLoginBtnClick,
+  onEmailChange,
+  onPasswordChange,
+  onMovesignUpBtnClick,
+}: LoginModalContentProps): JSX.Element => {
   const classes = useStyles();
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [isValidEmail, setIsValidEmail] = useState(true);
-  const [isValidPassword, setIsValidPassword] = useState(true);
-
-  const onDebouncedEmailChangeListener = debounce((e: React.ChangeEvent<HTMLInputElement>) => {
-    const { value: emailIDValue } = e.target;
-
-    setEmail(emailIDValue);
-    setIsValidEmail(isEmailID(emailIDValue));
-  }, 500);
-
-  const onDebouncedPasswordChangeListener = debounce((e: React.ChangeEvent<HTMLInputElement>) => {
-    const { value: passwordValue } = e.target;
-
-    setPassword(passwordValue);
-    setIsValidPassword(isPassword(passwordValue));
-  }, 500);
 
   return (
     <>
@@ -89,7 +79,7 @@ const LoginModalContent = ({ onModalClose }: LoginModalContentProps): JSX.Elemen
           variant="outlined"
           required
           fullWidth
-          onChange={onDebouncedEmailChangeListener}
+          onChange={onEmailChange}
         />
         <TextField
           autoComplete="off"
@@ -100,15 +90,15 @@ const LoginModalContent = ({ onModalClose }: LoginModalContentProps): JSX.Elemen
           variant="outlined"
           required
           fullWidth
-          onChange={onDebouncedPasswordChangeListener}
+          onChange={onPasswordChange}
         />
       </DialogContent>
       <DialogActions className={classes.dialogActionRoot}>
-        <Button btnType={ButtonType.primary} onClick={onModalClose} style={LOGIN_BUTTON_STYLE_PROPS} disabled fullWidth>
+        <Button btnType={ButtonType.primary} onClick={onLoginBtnClick} style={LOGIN_BUTTON_STYLE_PROPS} disabled={isLoginDisabled} fullWidth>
           로그인
         </Button>
         <div className={classes.linkTextArea}>
-          <Typography className={classes.linkText} variant="caption">
+          <Typography className={classes.linkText} variant="caption" onClick={onMovesignUpBtnClick}>
             한표를 더 편리하게 이용하세요. 회원가입하기
           </Typography>
         </div>

--- a/client/src/components/UI/molecules/LoginModalContent/LoginModalContent.tsx
+++ b/client/src/components/UI/molecules/LoginModalContent/LoginModalContent.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { Button, DialogTitle, DialogContent, DialogActions, TextField } from '@material-ui/core';
+import { DialogTitle, DialogContent, DialogActions, TextField, Typography } from '@material-ui/core';
+import { Button, ButtonType } from '@/components/UI/atoms';
 import { makeStyles } from '@material-ui/core/styles';
 import { debounce } from '@/common/utils';
 import { isEmailID, isPassword } from '@/common/utils/validator';
@@ -19,18 +20,37 @@ const useStyles = makeStyles((theme) => ({
     fontSize: '1.7rem',
     color: theme.palette.primary.main,
   },
+  dialogContentRoot: {
+    '&.MuiDialogContent-root': {
+      overflow: 'hidden',
+    },
+  },
+  dialogActionRoot: {
+    display: 'flex',
+    flexDirection: 'column',
+
+    '&.MuiDialogActions-root': {
+      padding: '1rem 1.5rem',
+    },
+  },
+  linkTextArea: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    width: '100%',
+    paddingTop: '1rem',
+    margin: '0 !important',
+  },
+  linkText: {
+    color: theme.palette.grey[600],
+    '&:hover': {
+      color: theme.palette.primary.main,
+      textDecoration: 'underline',
+      cursor: 'pointer',
+    },
+  },
 }));
 
-const HELPER_TEXT = {
-  EMAIL: {
-    DEFAULT: 'koreatech.ac.kr은 빼고 입력해주세요.',
-    ERROR: 'Email 형식이 적합하지 않습니다.',
-  },
-  PASSWORD: {
-    DEFAULT: 'Password는 8자 이상 12자 이하로 입력해주세요.',
-    ERROR: 'Password 형식이 적합하지 않습니다.',
-  },
-};
+const LOGIN_BUTTON_STYLE_PROPS = { width: 192, height: 35.2, borderRadius: 4, fontSize: 16 };
 
 const LoginModalContent = ({ onModalClose }: LoginModalContentProps): JSX.Element => {
   const classes = useStyles();
@@ -58,35 +78,40 @@ const LoginModalContent = ({ onModalClose }: LoginModalContentProps): JSX.Elemen
       <DialogTitle className={classes.title} id="login-dialog-title" disableTypography>
         한표 로그인
       </DialogTitle>
-      <DialogContent>
+      <DialogContent className={classes.dialogContentRoot}>
         <TextField
           autoComplete="off"
-          helperText={isValidEmail ? HELPER_TEXT.EMAIL.DEFAULT : HELPER_TEXT.EMAIL.ERROR}
-          error={!isValidEmail}
           autoFocus
           margin="dense"
           id="id"
           label="아이디"
           type="email"
+          variant="outlined"
+          required
           fullWidth
           onChange={onDebouncedEmailChangeListener}
         />
         <TextField
           autoComplete="off"
-          helperText={isValidPassword ? HELPER_TEXT.PASSWORD.DEFAULT : HELPER_TEXT.PASSWORD.ERROR}
-          error={!isValidPassword}
           margin="dense"
           id="password"
           label="비밀번호"
           type="password"
+          variant="outlined"
+          required
           fullWidth
           onChange={onDebouncedPasswordChangeListener}
         />
       </DialogContent>
-      <DialogActions>
-        <Button onClick={onModalClose} color="primary">
+      <DialogActions className={classes.dialogActionRoot}>
+        <Button btnType={ButtonType.primary} onClick={onModalClose} style={LOGIN_BUTTON_STYLE_PROPS} disabled fullWidth>
           로그인
         </Button>
+        <div className={classes.linkTextArea}>
+          <Typography className={classes.linkText} variant="caption">
+            한표를 더 편리하게 이용하세요. 회원가입하기
+          </Typography>
+        </div>
       </DialogActions>
     </>
   );

--- a/client/src/components/UI/organisms/ModalPopup/LoginModalPopup.stories.tsx
+++ b/client/src/components/UI/organisms/ModalPopup/LoginModalPopup.stories.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { withKnobs } from '@storybook/addon-knobs';
 import { Story, Meta } from '@storybook/react/types-6-0';
 import { action } from '@storybook/addon-actions';
-import { LoginModalType } from '@/components/UI/molecules';
 import { LoginModalPopup, LoginModalPopupProps } from './LoginModalPopup';
 
 export default {
@@ -16,7 +15,5 @@ const Template: Story<LoginModalPopupProps> = (args) => <LoginModalPopup {...arg
 export const Default = Template.bind({});
 Default.args = {
   modalOpen: true,
-  modalType: LoginModalType.LOGIN_MODAL,
   onModalAreaClose: action('onClick'),
-  onModalBtnClick: action('onClick'),
 };

--- a/client/src/components/UI/organisms/ModalPopup/LoginModalPopup.tsx
+++ b/client/src/components/UI/organisms/ModalPopup/LoginModalPopup.tsx
@@ -1,16 +1,59 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { ModalPopupArea, LoginModalContent } from '@/components/UI/molecules';
+import { modalTypes } from '@/components/UI/organisms';
+import { debounce } from '@/common/utils';
+import { useStores } from '@/stores';
 
 interface LoginModalPopupProps {
   modalOpen: boolean;
   onModalAreaClose: () => void;
-  onModalBtnClick: () => void;
 }
 
-const LoginModalPopup = ({ modalOpen, onModalAreaClose, onModalBtnClick }: LoginModalPopupProps): JSX.Element => {
+const LoginModalPopup = ({ modalOpen, onModalAreaClose }: LoginModalPopupProps): JSX.Element => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const { modalStore } = useStores();
+
+  const onDebouncedEmailChangeListener = debounce((e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value: emailIDValue } = e.target;
+
+    setEmail(emailIDValue);
+  }, 500);
+
+  const onDebouncedPasswordChangeListener = debounce((e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value: passwordValue } = e.target;
+
+    setPassword(passwordValue);
+  }, 500);
+
+  const onLoginBtnClickListener = () => {
+    alert('login');
+  };
+
+  const onMoveSignUpBtnClickListener = () => {
+    modalStore.changeModalState(modalTypes.SIGN_UP_MODAL, true);
+  };
+
+  const checkEmptyFormDatas = (): boolean => {
+    return !(email && password);
+  };
+
+  const checkLoginDisabled = (): boolean => {
+    const isExistEmptyFormDatas = checkEmptyFormDatas();
+
+    return isExistEmptyFormDatas;
+  };
+
   return (
     <ModalPopupArea modalOpen={modalOpen} onModalClose={onModalAreaClose}>
-      <LoginModalContent onModalClose={onModalBtnClick} />
+      <LoginModalContent
+        isLoginDisabled={checkLoginDisabled()}
+        onLoginBtnClick={onLoginBtnClickListener}
+        onEmailChange={onDebouncedEmailChangeListener}
+        onPasswordChange={onDebouncedPasswordChangeListener}
+        onMovesignUpBtnClick={onMoveSignUpBtnClickListener}
+      />
     </ModalPopupArea>
   );
 };

--- a/client/src/components/UI/organisms/ModalPopup/LoginModalPopup.tsx
+++ b/client/src/components/UI/organisms/ModalPopup/LoginModalPopup.tsx
@@ -35,6 +35,16 @@ const LoginModalPopup = ({ modalOpen, onModalAreaClose }: LoginModalPopupProps):
     modalStore.changeModalState(modalTypes.SIGN_UP_MODAL, true);
   };
 
+  const resetLoginForm = () => {
+    setEmail('');
+    setPassword('');
+  };
+
+  const onLoginModalCloseListener = () => {
+    resetLoginForm();
+    onModalAreaClose();
+  };
+
   const checkEmptyFormDatas = (): boolean => {
     return !(email && password);
   };
@@ -46,7 +56,7 @@ const LoginModalPopup = ({ modalOpen, onModalAreaClose }: LoginModalPopupProps):
   };
 
   return (
-    <ModalPopupArea modalOpen={modalOpen} onModalClose={onModalAreaClose}>
+    <ModalPopupArea modalOpen={modalOpen} onModalClose={onLoginModalCloseListener}>
       <LoginModalContent
         isLoginDisabled={checkLoginDisabled()}
         onLoginBtnClick={onLoginBtnClickListener}

--- a/client/src/components/UI/organisms/ModalPopup/LoginModalPopup.tsx
+++ b/client/src/components/UI/organisms/ModalPopup/LoginModalPopup.tsx
@@ -1,19 +1,33 @@
 import React, { useState } from 'react';
+import { SnackbarType } from '@/components/UI/atoms';
 import { ModalPopupArea, LoginModalContent } from '@/components/UI/molecules';
 import { modalTypes } from '@/components/UI/organisms';
 import { debounce } from '@/common/utils';
 import { useStores } from '@/stores';
+import { useFetchAsync } from '@/common/hooks';
 
 interface LoginModalPopupProps {
   modalOpen: boolean;
   onModalAreaClose: () => void;
 }
 
+const LOGIN_URL = '/api/login';
+const FETCH_OPTION = { method: 'POST' };
+
 const LoginModalPopup = ({ modalOpen, onModalAreaClose }: LoginModalPopupProps): JSX.Element => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
 
-  const { modalStore } = useStores();
+  const { modalStore, snackbarStore } = useStores();
+
+  const [login] = useFetchAsync(LOGIN_URL, FETCH_OPTION, {
+    onCompleted: () => {
+      snackbarStore.setSnackbarType(SnackbarType.LOGIN_SUCCESS);
+      snackbarStore.setSnackbarState(true);
+
+      modalStore.setModalState(false);
+    },
+  });
 
   const onDebouncedEmailChangeListener = debounce((e: React.ChangeEvent<HTMLInputElement>) => {
     const { value: emailIDValue } = e.target;
@@ -28,7 +42,7 @@ const LoginModalPopup = ({ modalOpen, onModalAreaClose }: LoginModalPopupProps):
   }, 500);
 
   const onLoginBtnClickListener = () => {
-    alert('login');
+    login({ email, password });
   };
 
   const onMoveSignUpBtnClickListener = () => {

--- a/client/src/components/UI/organisms/ModalPopup/LoginModalPopup.tsx
+++ b/client/src/components/UI/organisms/ModalPopup/LoginModalPopup.tsx
@@ -12,7 +12,9 @@ interface LoginModalPopupProps {
 }
 
 const LOGIN_URL = '/api/login';
-const FETCH_OPTION = { method: 'POST' };
+const FETCH_OPTION = {
+  method: 'POST',
+};
 
 const LoginModalPopup = ({ modalOpen, onModalAreaClose }: LoginModalPopupProps): JSX.Element => {
   const [email, setEmail] = useState('');
@@ -26,6 +28,10 @@ const LoginModalPopup = ({ modalOpen, onModalAreaClose }: LoginModalPopupProps):
       snackbarStore.setSnackbarState(true);
 
       modalStore.setModalState(false);
+    },
+    onError: () => {
+      snackbarStore.setSnackbarType(SnackbarType.LOGIN_FAILED);
+      snackbarStore.setSnackbarState(true);
     },
   });
 
@@ -42,7 +48,7 @@ const LoginModalPopup = ({ modalOpen, onModalAreaClose }: LoginModalPopupProps):
   }, 500);
 
   const onLoginBtnClickListener = () => {
-    login({ email, password });
+    login({ queryData: { email, password } });
   };
 
   const onMoveSignUpBtnClickListener = () => {

--- a/client/src/components/UI/organisms/ModalPopup/ModalPopup.tsx
+++ b/client/src/components/UI/organisms/ModalPopup/ModalPopup.tsx
@@ -64,7 +64,7 @@ const ModalPopup = (): JSX.Element => {
           onModalAreaClose={onModalCloseListener}
         />
       );
-    return <LoginModalPopup modalOpen={nowModalState} onModalBtnClick={() => {}} onModalAreaClose={onModalCloseListener} />;
+    return <LoginModalPopup modalOpen={nowModalState} onModalAreaClose={onModalCloseListener} />;
   };
 
   return <>{getModalPopup()}</>;

--- a/client/src/setupProxy.js
+++ b/client/src/setupProxy.js
@@ -10,4 +10,12 @@ module.exports = function (app) {
       logLevel: 'debug',
     }),
   );
+
+  app.use(
+    createProxyMiddleware('/api', {
+      target: 'https://hanpyo-server.herokuapp.com',
+      changeOrigin: true,
+      logLevel: 'debug',
+    }),
+  );
 };


### PR DESCRIPTION
## 📑 제목

#76 #101 로그인 폼 UI 변경 및 로그인 기능 구현 

## 💬 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 로그인 폼 UI 변경 및 스토리 코드 수정
   - 회원가입 폼 과는 달리 로그인 폼에서는 폼 데이터에 대한 유효성 검사 및 에러 메세지를 출력하지 않도록 구현했습니다!
   - 회원가입 폼으로 바로 이동할 수 있도록 구현했습니다. (로그인 버튼 하단 링크 클릭)
![image](https://user-images.githubusercontent.com/32856129/117795686-5f0ec800-b289-11eb-8a00-e6d3dca02060.png)

- [x] 로그인 기능 구현
   - 아이디, 비밀번호가 빈 값이 아니면 로그인 버튼 활성화
   - 로그인 버튼 클릭시 로그인 API 요청
   - API 결과에 따른 로그인 성공 or 실패 메세지 보여줌 
- [x] 기타 작업 사항
   - 클라이언트 REST API proxy 설정 추가
   - AlerSnackbar 로그인 메세지 추가
   - useFetchAsync hook API 제작
     - REST API 요청에 대한 useFetchAsync 훅을 제작했습니다.
     - useFetchAsync 호출시 바로 fetching하는 것이 아닌 return 값으로 전달 받은 fetching 함수를 필요한 순간(이벤트 등)에 호출할 수 있는 방식으로 제작했습니다. 
     - Apollo Client의 useMutation hook과 비슷하게 제작했습니다. (사용방법에 대한 통일 및 사용법이 좋아보여서용!)
     - fetching 결과에 대한 핸들링 방법은 useMutation과 동일하게 callback을 전달하는 방식으로 구현했습니다 
     - useMutation에서 callback 전달말고도 상태값으로 핸들링도 가능해보이지만 필요한 순간에 호출하다보니 콜백을 전달하는 방식이 제일 깔끔해보여서요!
     - 쿼리 파라미터와 바디 데이터 모두 fetching할 때 사용가능하도록 제작

## 🚧 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 로그인 성공시 보이는 프로필 UI는 코드 머지 후에 새로운 이슈를 열어서 작업할 예정입니다 :)
- 현재 서버쪽 로그인 로직이 쿼리 파라미터로 로그인 정보를 전달해야해서 쿼리 파라미터로 전달하고 있습니다. 추후 서버 로직이 변경되면 그때 바디로 보낼 수 있도록 수정하죠!