### PR TITLE
Heroku 서버 Proxy 설정 변경

### DIFF
--- a/static.json
+++ b/static.json
@@ -5,14 +5,14 @@
     },
     "proxies": {
       "/api/": {
-        "origin": "https://hanpyo-server.herokuapp.com/"
+        "origin": "https://hanpyo-server.herokuapp.com/api/"
       },
       "/graphql": {
-        "origin": "https://hanpyo-server.herokuapp.com/"
+        "origin": "https://hanpyo-server.herokuapp.com/graphql"
       }
     },
     "logging": {
-        "access": false,
+        "access": true,
         "error": "debug"
     }
 }


### PR DESCRIPTION
## 📑 제목

Heroku 서버 Proxy 설정 변경


## 💬 작업 내용

> 구현 내용 및 작업 했던 내역

- [X] 접속 로그도 추가
- [X] proxy URL 설정 변경
  - CRA에서 proxy 설정처럼 요청 주소에서 '/api/'에 문자열 매칭 검사를 수행 후,  API 주소가 아닌 도메인 주소만 변경해줄 것이라 생각했는데, 매칭 검사 후 매칭된 문자열을 요청 주소에서 삭제를 시키고 Proxy 주소를 변경한 뒤 요청하여 문제가 발생했습니다...
    ```
     // 기존 proxy 설정
    "proxies": {
      "/api/": {
        "origin": "https://hanpyo-server.herokuapp.com/"
      },
      "/graphql": {
        "origin": "https://hanpyo-server.herokuapp.com/"
      }
    }
    // proxy 예상 동작
    // request : https://hanpyo-server.herokuapp.com/api/login
    
    // 실제 동작
    // request : https://hanpyo-server.herokuapp.com/login  // "/api/"가 삭제됨
    ```
  - 현재 주소를 매칭 검사를 수행하는 문자열까지 포함하니 Proxy가 잘 동작합니다 :)
  

## 🚧 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 공식문서에서 설명이 참... 직관적이지 않게 되어있네용 ㅠ.ㅠ
- 관련 문서 - https://github.com/mars/create-react-app-buildpack#proxy-url-prefix