### PR TITLE
초기화 및 기타 작업

### DIFF
--- a/src/components/Skeleton/LectureListSkeleton/LectureListSkeleton.tsx
+++ b/src/components/Skeleton/LectureListSkeleton/LectureListSkeleton.tsx
@@ -9,7 +9,7 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'center',
-    width: '35rem',
+    width: '43rem',
     height: '19rem',
     marginTop: '1.2rem',
     border: `1px solid ${theme.palette.grey[400]}`,

--- a/src/components/UI/atoms/LectureInfoTitle/LectureInfoTitle.tsx
+++ b/src/components/UI/atoms/LectureInfoTitle/LectureInfoTitle.tsx
@@ -19,10 +19,6 @@ interface TitleProps {
   isHeader: boolean;
 }
 
-interface CSSProps {
-  isHeader: boolean;
-}
-
 const useStyles = makeStyles((theme) => ({
   default: {
     display: 'flex',
@@ -58,18 +54,25 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'center',
-    color: (props: CSSProps) => (props.isHeader ? theme.palette.grey[500] : theme.palette.grey[800]),
+    color: theme.palette.grey[800],
+  },
+  headerText: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+    color: theme.palette.grey[500],
   },
 }));
 
 const LectureInfoTitle = ({ className, children, isHeader }: TitleProps): JSX.Element => {
-  const classes = useStyles({ isHeader });
+  const classes = useStyles();
   const getClassName = () => {
     return { ...classes }[className];
   };
   return (
     <div className={`${classes.default} ${getClassName()}`}>
-      <Typography className={classes.text} variant="caption">
+      <Typography className={isHeader ? classes.headerText : classes.text} variant="caption">
         {children}
       </Typography>
     </div>

--- a/src/components/UI/atoms/LectureInfoTitle/LectureInfoTitle.tsx
+++ b/src/components/UI/atoms/LectureInfoTitle/LectureInfoTitle.tsx
@@ -11,6 +11,8 @@ enum LectureInfoTitleType {
   personnel = 'personnel',
   dept = 'dept',
   time = 'time',
+  room = 'room',
+  credit = 'credit',
 }
 
 interface TitleProps {
@@ -26,28 +28,34 @@ const useStyles = makeStyles((theme) => ({
     alignItems: 'center',
   },
   code: {
-    width: '10%',
+    width: '8%',
   },
   name: {
-    width: '24%',
+    width: '19%',
   },
   class: {
-    width: '5%',
+    width: '4%',
   },
   prof: {
-    width: '12%',
+    width: '10%',
   },
   grade: {
-    width: '5%',
+    width: '4%',
   },
   personnel: {
-    width: '5%',
+    width: '4%',
   },
   dept: {
-    width: '21%',
+    width: '19%',
   },
   time: {
-    width: '18%',
+    width: '15%',
+  },
+  room: {
+    width: '13%',
+  },
+  credit: {
+    width: '4%',
   },
   text: {
     display: 'flex',

--- a/src/components/UI/atoms/SelectMenu/SelectMenu.tsx
+++ b/src/components/UI/atoms/SelectMenu/SelectMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import { Popover } from '@material-ui/core';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';

--- a/src/components/UI/atoms/SelectMenu/SelectMenu.tsx
+++ b/src/components/UI/atoms/SelectMenu/SelectMenu.tsx
@@ -3,7 +3,6 @@ import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import { Popover } from '@material-ui/core';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { calculateScrollHeight, scrollDownToBottom } from '@/common/utils/scroll';
-import { useStores } from '@/stores';
 
 interface MenuItemType {
   id: number;
@@ -12,6 +11,8 @@ interface MenuItemType {
 }
 
 interface SelectMenuProps {
+  state: string;
+  setState: React.Dispatch<React.SetStateAction<string>>;
   menuLabel: string;
   menus: MenuItemType[];
   dropMenuWidth?: number | string;
@@ -72,18 +73,10 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-const SelectMenu = ({ menuLabel, menus, dropMenuWidth = 'auto', onSelectMenuChange }: SelectMenuProps): JSX.Element => {
+const SelectMenu = ({ menuLabel, menus, dropMenuWidth = 'auto', onSelectMenuChange, state, setState }: SelectMenuProps): JSX.Element => {
   const [anchorEl, setAnchorEl] = useState<Element | null>(null);
-  const [selectValue, setSelectValue] = useState('');
-  const { lectureInfoStore } = useStores();
   const open = Boolean(anchorEl);
   const classes = useStyles({ open, dropMenuWidth });
-
-  useEffect(() => {
-    if (lectureInfoStore.state.isInit()) {
-      setSelectValue('');
-    }
-  });
 
   const getMenuItems = (): JSX.Element[] => {
     const menuItems = menus.map((menu) => (
@@ -105,7 +98,6 @@ const SelectMenu = ({ menuLabel, menus, dropMenuWidth = 'auto', onSelectMenuChan
   };
 
   const onMenuBoxClickListener = (event: React.MouseEvent<HTMLElement>) => {
-    lectureInfoStore.state.isInit(false);
     const eventTarget = event.currentTarget;
     scrollDown(eventTarget);
     setAnchorEl(eventTarget);
@@ -123,7 +115,7 @@ const SelectMenu = ({ menuLabel, menus, dropMenuWidth = 'auto', onSelectMenuChan
 
     const { dataset } = liElement;
     const nowSelectedValue = dataset?.title ?? '';
-    setSelectValue(nowSelectedValue);
+    setState(nowSelectedValue);
     setAnchorEl(null);
 
     if (onSelectMenuChange) {
@@ -134,8 +126,8 @@ const SelectMenu = ({ menuLabel, menus, dropMenuWidth = 'auto', onSelectMenuChan
   return (
     <>
       <div className={classes.root} onClick={onMenuBoxClickListener}>
-        <span className={classes.label}>{selectValue || menuLabel}</span>
-        <input type="hidden" aria-hidden="true" value={selectValue} />
+        <span className={classes.label}>{state || menuLabel}</span>
+        <input type="hidden" aria-hidden="true" value={state} />
         <ExpandMoreIcon className={classes.icon} />
       </div>
       <Popover

--- a/src/components/UI/atoms/SelectMenu/SelectMenu.tsx
+++ b/src/components/UI/atoms/SelectMenu/SelectMenu.tsx
@@ -1,8 +1,9 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import { Popover } from '@material-ui/core';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { calculateScrollHeight, scrollDownToBottom } from '@/common/utils/scroll';
+import { useStores } from '@/stores';
 
 interface MenuItemType {
   id: number;
@@ -74,9 +75,15 @@ const useStyles = makeStyles((theme: Theme) =>
 const SelectMenu = ({ menuLabel, menus, dropMenuWidth = 'auto', onSelectMenuChange }: SelectMenuProps): JSX.Element => {
   const [anchorEl, setAnchorEl] = useState<Element | null>(null);
   const [selectValue, setSelectValue] = useState('');
-
+  const { lectureInfoStore } = useStores();
   const open = Boolean(anchorEl);
   const classes = useStyles({ open, dropMenuWidth });
+
+  useEffect(() => {
+    if (lectureInfoStore.state.isInit()) {
+      setSelectValue('');
+    }
+  });
 
   const getMenuItems = (): JSX.Element[] => {
     const menuItems = menus.map((menu) => (
@@ -108,6 +115,7 @@ const SelectMenu = ({ menuLabel, menus, dropMenuWidth = 'auto', onSelectMenuChan
   };
 
   const onMenuClickListener = (event: React.MouseEvent<HTMLElement>) => {
+    lectureInfoStore.state.isInit(false);
     const target = event.target as HTMLElement;
     const liElement = target.closest('li');
 

--- a/src/components/UI/atoms/SelectMenu/SelectMenu.tsx
+++ b/src/components/UI/atoms/SelectMenu/SelectMenu.tsx
@@ -105,6 +105,7 @@ const SelectMenu = ({ menuLabel, menus, dropMenuWidth = 'auto', onSelectMenuChan
   };
 
   const onMenuBoxClickListener = (event: React.MouseEvent<HTMLElement>) => {
+    lectureInfoStore.state.isInit(false);
     const eventTarget = event.currentTarget;
     scrollDown(eventTarget);
     setAnchorEl(eventTarget);
@@ -115,7 +116,6 @@ const SelectMenu = ({ menuLabel, menus, dropMenuWidth = 'auto', onSelectMenuChan
   };
 
   const onMenuClickListener = (event: React.MouseEvent<HTMLElement>) => {
-    lectureInfoStore.state.isInit(false);
     const target = event.target as HTMLElement;
     const liElement = target.closest('li');
 

--- a/src/components/UI/atoms/TimeSelectMenu/TimeSelectMenu.tsx
+++ b/src/components/UI/atoms/TimeSelectMenu/TimeSelectMenu.tsx
@@ -1,10 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import { Popover } from '@material-ui/core';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { range } from '@/common/utils';
 import { calculateScrollHeight, scrollDownToBottom } from '@/common/utils/scroll';
-import { useStores } from '@/stores';
 
 enum TimeSelectMenuItemType {
   AM_PM = 'AM_PM',
@@ -20,6 +19,8 @@ interface TimeSelectMenuDataType {
 }
 
 interface TimeSelectMenuProps {
+  state: boolean;
+  setState: React.Dispatch<React.SetStateAction<boolean>>;
   menuLabel: string;
   dropMenuWidth?: number | string;
   onSelectMenuChange: (value: number) => void;
@@ -113,19 +114,11 @@ const MINUTE_DATAS = Array.from(range(0, 30, 30)).map((minute, idx) => ({
   type: TimeSelectMenuItemType.MINUTE,
 }));
 
-const TimeSelectMenu = ({ menuLabel, dropMenuWidth = 'auto', onSelectMenuChange }: TimeSelectMenuProps): JSX.Element => {
+const TimeSelectMenu = ({ state, setState, menuLabel, dropMenuWidth = 'auto', onSelectMenuChange }: TimeSelectMenuProps): JSX.Element => {
   const [anchorEl, setAnchorEl] = React.useState<Element | null>(null);
-  const [isSelected, setIsSelected] = useState(false);
   const [selectedAMPM, setSelectedAMPM] = useState('오전');
   const [selectedHour, setSelectedHour] = useState('01');
   const [selectedMinute, setSelectedMinute] = useState('00');
-  const { lectureInfoStore } = useStores();
-
-  useEffect(() => {
-    if (lectureInfoStore.state.isInit()) {
-      setIsSelected(false);
-    }
-  });
 
   const selectedValue = `${selectedAMPM}${selectedHour && `  ${selectedHour} : `}${selectedMinute}`;
 
@@ -162,12 +155,11 @@ const TimeSelectMenu = ({ menuLabel, dropMenuWidth = 'auto', onSelectMenuChange 
   };
 
   const onMenuBoxClickListener = (event: React.MouseEvent<HTMLElement>) => {
-    lectureInfoStore.state.isInit(false);
     const eventTarget = event.currentTarget;
 
     scrollDown(eventTarget);
     setAnchorEl(eventTarget);
-    setIsSelected(true);
+    setState(true);
   };
 
   const onMenuCloseListener = () => {
@@ -215,7 +207,7 @@ const TimeSelectMenu = ({ menuLabel, dropMenuWidth = 'auto', onSelectMenuChange 
   return (
     <>
       <div className={classes.root} onClick={onMenuBoxClickListener}>
-        <span className={classes.label}>{isSelected ? selectedValue : menuLabel}</span>
+        <span className={classes.label}>{state ? selectedValue : menuLabel}</span>
         <input type="hidden" aria-hidden="true" value={selectedValue} />
         <ExpandMoreIcon className={classes.icon} />
       </div>

--- a/src/components/UI/atoms/TimeSelectMenu/TimeSelectMenu.tsx
+++ b/src/components/UI/atoms/TimeSelectMenu/TimeSelectMenu.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import { Popover } from '@material-ui/core';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { range } from '@/common/utils';
 import { calculateScrollHeight, scrollDownToBottom } from '@/common/utils/scroll';
+import { useStores } from '@/stores';
 
 enum TimeSelectMenuItemType {
   AM_PM = 'AM_PM',
@@ -118,6 +119,13 @@ const TimeSelectMenu = ({ menuLabel, dropMenuWidth = 'auto', onSelectMenuChange 
   const [selectedAMPM, setSelectedAMPM] = useState('오전');
   const [selectedHour, setSelectedHour] = useState('01');
   const [selectedMinute, setSelectedMinute] = useState('00');
+  const { lectureInfoStore } = useStores();
+
+  useEffect(() => {
+    if (lectureInfoStore.state.isInit()) {
+      setIsSelected(false);
+    }
+  });
 
   const selectedValue = `${selectedAMPM}${selectedHour && `  ${selectedHour} : `}${selectedMinute}`;
 
@@ -154,6 +162,7 @@ const TimeSelectMenu = ({ menuLabel, dropMenuWidth = 'auto', onSelectMenuChange 
   };
 
   const onMenuBoxClickListener = (event: React.MouseEvent<HTMLElement>) => {
+    lectureInfoStore.state.isInit(false);
     const eventTarget = event.currentTarget;
 
     scrollDown(eventTarget);

--- a/src/components/UI/molecules/LectureInfo/LectureInfo.tsx
+++ b/src/components/UI/molecules/LectureInfo/LectureInfo.tsx
@@ -59,7 +59,7 @@ interface LectureInfos {
   room?: string;
   requiredGrade?: number | string;
   requiredMajor?: string;
-  credit?: number;
+  credit?: number | string;
   color?: string;
 }
 
@@ -158,6 +158,14 @@ const LectureInfo = ({ isHeader = false, infos, onDoubleClick, onClick, isBasket
         <LectureInfoDivider />
         <LectureInfoTitle className={LectureInfoTitleType.dept} isHeader={isHeader}>
           {infos.department}
+        </LectureInfoTitle>
+        <LectureInfoDivider />
+        <LectureInfoTitle className={LectureInfoTitleType.room} isHeader={isHeader}>
+          {infos.room}
+        </LectureInfoTitle>
+        <LectureInfoDivider />
+        <LectureInfoTitle className={LectureInfoTitleType.credit} isHeader={isHeader}>
+          {infos.credit}
         </LectureInfoTitle>
         <LectureInfoDivider />
         <LectureInfoTitle className={LectureInfoTitleType.time} isHeader={isHeader}>

--- a/src/components/UI/molecules/LectureInfo/LectureInfo.tsx
+++ b/src/components/UI/molecules/LectureInfo/LectureInfo.tsx
@@ -121,6 +121,39 @@ const LectureInfo = ({ isHeader = false, infos, onDoubleClick, onClick, isBasket
     });
   };
 
+  const lectureInfoArray = [
+    { type: LectureInfoTitleType.code, children: infos.code },
+    { type: LectureInfoTitleType.name, children: infos.name },
+    { type: LectureInfoTitleType.class, children: infos.divisionNumber },
+    { type: LectureInfoTitleType.prof, children: infos.professor },
+    { type: LectureInfoTitleType.personnel, children: infos.totalStudentNumber },
+    { type: LectureInfoTitleType.grade, children: infos.requiredMajor },
+    { type: LectureInfoTitleType.dept, children: infos.department },
+    { type: LectureInfoTitleType.room, children: infos.room },
+    { type: LectureInfoTitleType.credit, children: infos.credit },
+  ];
+
+  const getLectureInfo = () => {
+    const lectureInfo = lectureInfoArray.map((info) => {
+      return (
+        <>
+          <LectureInfoTitle key={info.children} className={info.type} isHeader={isHeader}>
+            {info.children}
+          </LectureInfoTitle>
+          <LectureInfoDivider />
+        </>
+      );
+    });
+    const timeInfo = (
+      <>
+        <LectureInfoTitle className={LectureInfoTitleType.time} isHeader={isHeader}>
+          {getLectureTimes(infos.lectureTimes)}
+        </LectureInfoTitle>
+      </>
+    );
+    return [...lectureInfo, timeInfo];
+  };
+
   return (
     <Tooltip
       title={isBasketList ? LECTURE_INFO_TOOLTIP_MESSAGE.REMOVE_MESSAGE : LECTURE_INFO_TOOLTIP_MESSAGE.ADD_MESSAGE}
@@ -132,45 +165,7 @@ const LectureInfo = ({ isHeader = false, infos, onDoubleClick, onClick, isBasket
         data-selected={checkSelectedLecture()}
         onClick={() => onClick(infos)}
         onDoubleClick={() => onDoubleClick(infos)}>
-        <LectureInfoTitle className={LectureInfoTitleType.code} isHeader={isHeader}>
-          {infos.code}
-        </LectureInfoTitle>
-        <LectureInfoDivider />
-        <LectureInfoTitle className={LectureInfoTitleType.name} isHeader={isHeader}>
-          {infos.name}
-        </LectureInfoTitle>
-        <LectureInfoDivider />
-        <LectureInfoTitle className={LectureInfoTitleType.class} isHeader={isHeader}>
-          {infos.divisionNumber}
-        </LectureInfoTitle>
-        <LectureInfoDivider />
-        <LectureInfoTitle className={LectureInfoTitleType.prof} isHeader={isHeader}>
-          {infos.professor}
-        </LectureInfoTitle>
-        <LectureInfoDivider />
-        <LectureInfoTitle className={LectureInfoTitleType.personnel} isHeader={isHeader}>
-          {infos.totalStudentNumber}
-        </LectureInfoTitle>
-        <LectureInfoDivider />
-        <LectureInfoTitle className={LectureInfoTitleType.grade} isHeader={isHeader}>
-          {infos.requiredMajor}
-        </LectureInfoTitle>
-        <LectureInfoDivider />
-        <LectureInfoTitle className={LectureInfoTitleType.dept} isHeader={isHeader}>
-          {infos.department}
-        </LectureInfoTitle>
-        <LectureInfoDivider />
-        <LectureInfoTitle className={LectureInfoTitleType.room} isHeader={isHeader}>
-          {infos.room}
-        </LectureInfoTitle>
-        <LectureInfoDivider />
-        <LectureInfoTitle className={LectureInfoTitleType.credit} isHeader={isHeader}>
-          {infos.credit}
-        </LectureInfoTitle>
-        <LectureInfoDivider />
-        <LectureInfoTitle className={LectureInfoTitleType.time} isHeader={isHeader}>
-          {getLectureTimes(infos.lectureTimes)}
-        </LectureInfoTitle>
+        {getLectureInfo()}
       </div>
     </Tooltip>
   );

--- a/src/components/UI/molecules/LectureListContent/LectureListContent.tsx
+++ b/src/components/UI/molecules/LectureListContent/LectureListContent.tsx
@@ -64,6 +64,8 @@ const headerInfos = {
   requiredMajor: '대상',
   totalStudentNumber: '정원',
   department: '개설학부',
+  room: '강의실',
+  credit: '학점',
   lectureTimes: '시간',
 };
 

--- a/src/components/UI/molecules/LectureListContent/LectureListContent.tsx
+++ b/src/components/UI/molecules/LectureListContent/LectureListContent.tsx
@@ -16,7 +16,7 @@ interface CSSProps {
 
 const useStyles = makeStyles((theme) => ({
   rootWrapper: {
-    width: '35rem',
+    width: '43rem',
     height: (props: CSSProps) => (props.isBasket ? '12rem' : '19rem'),
     margin: '1.2rem 0 0 0',
     padding: '0 0.2rem 0.4rem 0.2rem',

--- a/src/components/UI/molecules/LectureSearchFilter/LectureSearchFilter.tsx
+++ b/src/components/UI/molecules/LectureSearchFilter/LectureSearchFilter.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import { Tooltip, IconButton } from '@material-ui/core';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import { SelectMenu, TimeSelectMenu, SelectMenuProps, TimeSelectMenuProps } from '@/components/UI/atoms';
+import RefreshRoundedIcon from '@material-ui/icons/RefreshRounded';
 
 interface LectureSearchFilterProps {
   majorSelectMenu: SelectMenuProps;
@@ -8,6 +10,7 @@ interface LectureSearchFilterProps {
   gradeSelectMenu: SelectMenuProps;
   startTimeSelectMenu: TimeSelectMenuProps;
   endTimeSelectMenu: TimeSelectMenuProps;
+  onInitButtonClickListener: () => void;
 }
 
 const DROP_MENU_WIDTH = {
@@ -24,7 +27,6 @@ const useStyles = makeStyles((theme: Theme) =>
       justifyContent: 'space-between',
       alignItems: 'center',
       marginTop: '1.2rem',
-
       '& > *': {
         marginRight: '0.3125rem',
       },
@@ -54,6 +56,7 @@ const LectureSearchFilter = ({
   gradeSelectMenu,
   startTimeSelectMenu,
   endTimeSelectMenu,
+  onInitButtonClickListener,
 }: LectureSearchFilterProps): JSX.Element => {
   const classes = useStyles();
 
@@ -74,6 +77,13 @@ const LectureSearchFilter = ({
       <span>&#126;</span>
       <div className={classes.timeSelect}>
         <TimeSelectMenu {...endTimeSelectMenu} dropMenuWidth={DROP_MENU_WIDTH.TIME} />
+      </div>
+      <div>
+        <Tooltip title="필터 초기화" onClick={onInitButtonClickListener}>
+          <IconButton aria-label="init filter">
+            <RefreshRoundedIcon color="primary" />
+          </IconButton>
+        </Tooltip>
       </div>
     </div>
   );

--- a/src/components/UI/molecules/LectureSearchFilter/LectureSearchFilter.tsx
+++ b/src/components/UI/molecules/LectureSearchFilter/LectureSearchFilter.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
-import { Tooltip, IconButton } from '@material-ui/core';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
-import { SelectMenu, TimeSelectMenu, SelectMenuProps, TimeSelectMenuProps } from '@/components/UI/atoms';
-import RefreshRoundedIcon from '@material-ui/icons/RefreshRounded';
+import { SelectMenu, TimeSelectMenu, SelectMenuProps, TimeSelectMenuProps, Button, ButtonType } from '@/components/UI/atoms';
 
 interface LectureSearchFilterProps {
   majorSelectMenu: SelectMenuProps;
@@ -14,11 +12,13 @@ interface LectureSearchFilterProps {
 }
 
 const DROP_MENU_WIDTH = {
-  MAJOR: '10rem',
-  DAY: '4.1875rem',
-  GRADE: '4.5rem',
-  TIME: '6.75rem',
+  MAJOR: '10.5rem',
+  DAY: '4.6875rem',
+  GRADE: '5rem',
+  TIME: '7.25rem',
 };
+
+const BUTTON_STYLE_PROPS = { width: 80, height: 32.25, borderRadius: 11.2, fontSize: 12 };
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -27,6 +27,7 @@ const useStyles = makeStyles((theme: Theme) =>
       justifyContent: 'space-between',
       alignItems: 'center',
       marginTop: '1.2rem',
+      width: '100%',
       '& > *': {
         marginRight: '0.3125rem',
       },
@@ -79,11 +80,9 @@ const LectureSearchFilter = ({
         <TimeSelectMenu {...endTimeSelectMenu} dropMenuWidth={DROP_MENU_WIDTH.TIME} />
       </div>
       <div>
-        <Tooltip title="필터 초기화" onClick={onInitButtonClickListener}>
-          <IconButton aria-label="init filter">
-            <RefreshRoundedIcon color="primary" />
-          </IconButton>
-        </Tooltip>
+        <Button btnType={ButtonType.primary} style={BUTTON_STYLE_PROPS} onClick={onInitButtonClickListener}>
+          초기화
+        </Button>
       </div>
     </div>
   );

--- a/src/components/UI/molecules/LectureSearchFilter/LectureSearchFilterMenu.tsx
+++ b/src/components/UI/molecules/LectureSearchFilter/LectureSearchFilterMenu.tsx
@@ -18,6 +18,7 @@ const LectureSearchFilterMenu = (): JSX.Element => {
       { id: 6, title: '산업경영학부', value: 6 },
       { id: 7, title: '교양학부', value: 7 },
       { id: 8, title: 'HRD학과', value: 8 },
+      { id: 9, title: '전체', value: 9 },
     ],
     onSelectMenuChange: (value: string) => {
       lectureInfoStore.state.searchWord(null);
@@ -34,6 +35,7 @@ const LectureSearchFilterMenu = (): JSX.Element => {
       { id: 3, title: '목', value: 3 },
       { id: 4, title: '금', value: 4 },
       { id: 5, title: '토', value: 5 },
+      { id: 6, title: '전체', value: 6 },
     ],
     onSelectMenuChange: (value: string) => {
       lectureInfoStore.state.searchWord(null);
@@ -48,6 +50,7 @@ const LectureSearchFilterMenu = (): JSX.Element => {
       { id: 1, title: '2학점', value: 1 },
       { id: 2, title: '3학점', value: 3 },
       { id: 3, title: '4학점', value: 4 },
+      { id: 4, title: '전체', value: 5 },
     ],
     onSelectMenuChange: (value: string) => {
       lectureInfoStore.state.searchWord(null);

--- a/src/components/UI/molecules/LectureSearchFilter/LectureSearchFilterMenu.tsx
+++ b/src/components/UI/molecules/LectureSearchFilter/LectureSearchFilterMenu.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useStores } from '@/stores';
 import { LectureSearchFilter } from './LectureSearchFilter';
 
 const LectureSearchFilterMenu = (): JSX.Element => {
   const { lectureInfoStore } = useStores();
+  const [initFlag, setInitFlag] = useState(true);
 
   const majorSelectMenuProps = {
     menuLabel: '개설학부',
@@ -77,7 +78,14 @@ const LectureSearchFilterMenu = (): JSX.Element => {
   };
 
   const onInitButtonClickListener = () => {
-    console.log('hi');
+    lectureInfoStore.state.isInit(true);
+    lectureInfoStore.state.searchWord(null);
+    lectureInfoStore.state.selectedDepartment(null);
+    lectureInfoStore.state.selectedCredit(null);
+    lectureInfoStore.state.selectedDay(null);
+    lectureInfoStore.state.selectedStartTime(null);
+    lectureInfoStore.state.selectedEndTime(null);
+    setInitFlag(!initFlag);
   };
 
   return (

--- a/src/components/UI/molecules/LectureSearchFilter/LectureSearchFilterMenu.tsx
+++ b/src/components/UI/molecules/LectureSearchFilter/LectureSearchFilterMenu.tsx
@@ -4,9 +4,15 @@ import { LectureSearchFilter } from './LectureSearchFilter';
 
 const LectureSearchFilterMenu = (): JSX.Element => {
   const { lectureInfoStore } = useStores();
-  const [initFlag, setInitFlag] = useState(true);
+  const [departmentState, setDepartmentState] = useState('');
+  const [dayState, setDayState] = useState('');
+  const [creditState, setCreditState] = useState('');
+  const [startTimeState, setStartTimeState] = useState(false);
+  const [endTimeState, setEndTimeState] = useState(false);
 
   const majorSelectMenuProps = {
+    state: departmentState,
+    setState: setDepartmentState,
     menuLabel: '개설학부',
     menus: [
       { id: 0, title: '컴퓨터공학부', value: 0 },
@@ -27,6 +33,8 @@ const LectureSearchFilterMenu = (): JSX.Element => {
   };
 
   const daySelectMenuProps = {
+    state: dayState,
+    setState: setDayState,
     menuLabel: '요일',
     menus: [
       { id: 0, title: '월', value: 0 },
@@ -44,6 +52,8 @@ const LectureSearchFilterMenu = (): JSX.Element => {
   };
 
   const gradeSelectMenuProps = {
+    state: creditState,
+    setState: setCreditState,
     menuLabel: '학점',
     menus: [
       { id: 0, title: '1학점', value: 0 },
@@ -59,6 +69,8 @@ const LectureSearchFilterMenu = (): JSX.Element => {
   };
 
   const startTimeSelectMenuProps = {
+    state: startTimeState,
+    setState: setStartTimeState,
     menuLabel: '시간',
     onSelectMenuChange: (value: number) => {
       lectureInfoStore.state.searchWord(null);
@@ -70,6 +82,8 @@ const LectureSearchFilterMenu = (): JSX.Element => {
   };
 
   const endTimeSelectMenuProps = {
+    state: endTimeState,
+    setState: setEndTimeState,
     menuLabel: '시간',
     onSelectMenuChange: (value: number) => {
       lectureInfoStore.state.searchWord(null);
@@ -88,7 +102,11 @@ const LectureSearchFilterMenu = (): JSX.Element => {
     lectureInfoStore.state.selectedDay(null);
     lectureInfoStore.state.selectedStartTime(null);
     lectureInfoStore.state.selectedEndTime(null);
-    setInitFlag(!initFlag);
+    setDepartmentState('');
+    setDayState('');
+    setCreditState('');
+    setStartTimeState(false);
+    setEndTimeState(false);
   };
 
   return (

--- a/src/components/UI/molecules/LectureSearchFilter/LectureSearchFilterMenu.tsx
+++ b/src/components/UI/molecules/LectureSearchFilter/LectureSearchFilterMenu.tsx
@@ -95,7 +95,6 @@ const LectureSearchFilterMenu = (): JSX.Element => {
   };
 
   const onInitButtonClickListener = () => {
-    lectureInfoStore.state.isInit(true);
     lectureInfoStore.state.searchWord(null);
     lectureInfoStore.state.selectedDepartment(null);
     lectureInfoStore.state.selectedCredit(null);

--- a/src/components/UI/molecules/LectureSearchFilter/LectureSearchFilterMenu.tsx
+++ b/src/components/UI/molecules/LectureSearchFilter/LectureSearchFilterMenu.tsx
@@ -76,6 +76,10 @@ const LectureSearchFilterMenu = (): JSX.Element => {
     },
   };
 
+  const onInitButtonClickListener = () => {
+    console.log('hi');
+  };
+
   return (
     <LectureSearchFilter
       majorSelectMenu={majorSelectMenuProps}
@@ -83,6 +87,7 @@ const LectureSearchFilterMenu = (): JSX.Element => {
       gradeSelectMenu={gradeSelectMenuProps}
       startTimeSelectMenu={startTimeSelectMenuProps}
       endTimeSelectMenu={endTimeSelectMenuProps}
+      onInitButtonClickListener={onInitButtonClickListener}
     />
   );
 };

--- a/src/components/UI/molecules/ReviewSearchSection/ReviewSearchSection.tsx
+++ b/src/components/UI/molecules/ReviewSearchSection/ReviewSearchSection.tsx
@@ -4,20 +4,24 @@ import CheckBox from '@material-ui/core/Checkbox';
 import { SelectMenu } from '@/components/UI/atoms';
 import { SearchBar } from '@/components/UI/molecules';
 
-const searchFilterSelectMenuProps = {
-  menuLabel: '정렬순서',
-  menus: [
-    { id: 0, title: '최신순', value: 0 },
-    { id: 1, title: '추천순', value: 1 },
-    { id: 2, title: '별점순', value: 3 },
-  ],
-  onSelectMenuChange: () => {
-    console.log('정렬 방법 선택');
-  },
-};
-
 const ReviewSearchSection = (): JSX.Element => {
   const [isChecked, setIsChecked] = useState(false);
+  const [searchFilterState, setSearchFilterState] = useState('');
+
+  const searchFilterSelectMenuProps = {
+    state: searchFilterState,
+    setState: setSearchFilterState,
+    menuLabel: '정렬순서',
+    menus: [
+      { id: 0, title: '최신순', value: 0 },
+      { id: 1, title: '추천순', value: 1 },
+      { id: 2, title: '별점순', value: 3 },
+    ],
+    onSelectMenuChange: () => {
+      console.log('정렬 방법 선택');
+    },
+  };
+
   const onCheckBoxChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
     setIsChecked(event.target.checked);
   };

--- a/src/components/UI/molecules/TimeTableAddForm/TimeTableAddForm.tsx
+++ b/src/components/UI/molecules/TimeTableAddForm/TimeTableAddForm.tsx
@@ -1,28 +1,34 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { TimeTableAddFormContent } from './TimeTableAddFormContent';
 
-const daySelectMenuProps = {
-  menuLabel: '요일',
-  menus: [
-    { id: 0, title: '월', value: 0 },
-    { id: 1, title: '화', value: 1 },
-    { id: 2, title: '수', value: 2 },
-    { id: 3, title: '목', value: 3 },
-    { id: 4, title: '금', value: 4 },
-  ],
-  onSelectMenuChange: () => {
-    console.log('요일선택');
-  },
-};
-
-const timeSelectMenuProps = {
-  menuLabel: '시간',
-  onSelectMenuChange: () => {
-    console.log('시간선택');
-  },
-};
-
 const TimeTableAddForm = (): JSX.Element => {
+  const [dayState, setDayState] = useState('');
+  const [timeState, setTimeState] = useState(false);
+
+  const daySelectMenuProps = {
+    state: dayState,
+    setState: setDayState,
+    menuLabel: '요일',
+    menus: [
+      { id: 0, title: '월', value: 0 },
+      { id: 1, title: '화', value: 1 },
+      { id: 2, title: '수', value: 2 },
+      { id: 3, title: '목', value: 3 },
+      { id: 4, title: '금', value: 4 },
+    ],
+    onSelectMenuChange: () => {
+      console.log('요일선택');
+    },
+  };
+
+  const timeSelectMenuProps = {
+    state: timeState,
+    setState: setTimeState,
+    menuLabel: '시간',
+    onSelectMenuChange: () => {
+      console.log('시간선택');
+    },
+  };
   const onTimeTableFormSubmitListener = () => {
     alert('submit!');
   };

--- a/src/components/UI/molecules/TimeTableAddForm/TimeTableAddForm.tsx
+++ b/src/components/UI/molecules/TimeTableAddForm/TimeTableAddForm.tsx
@@ -3,7 +3,8 @@ import { TimeTableAddFormContent } from './TimeTableAddFormContent';
 
 const TimeTableAddForm = (): JSX.Element => {
   const [dayState, setDayState] = useState('');
-  const [timeState, setTimeState] = useState(false);
+  const [startTimeState, setStartTimeState] = useState(false);
+  const [endTimeState, setEndTimeState] = useState(false);
 
   const daySelectMenuProps = {
     state: dayState,
@@ -21,9 +22,18 @@ const TimeTableAddForm = (): JSX.Element => {
     },
   };
 
-  const timeSelectMenuProps = {
-    state: timeState,
-    setState: setTimeState,
+  const startTimeSelectMenuProps = {
+    state: startTimeState,
+    setState: setStartTimeState,
+    menuLabel: '시간',
+    onSelectMenuChange: () => {
+      console.log('시간선택');
+    },
+  };
+
+  const endTimeSelectMenuProps = {
+    state: endTimeState,
+    setState: setEndTimeState,
     menuLabel: '시간',
     onSelectMenuChange: () => {
       console.log('시간선택');
@@ -36,7 +46,8 @@ const TimeTableAddForm = (): JSX.Element => {
   return (
     <TimeTableAddFormContent
       daySelectMenu={daySelectMenuProps}
-      timeSelectMenu={timeSelectMenuProps}
+      startTimeSelectMenu={startTimeSelectMenuProps}
+      endTimeSelectMenu={endTimeSelectMenuProps}
       onTimeTableFormSubmit={onTimeTableFormSubmitListener}
     />
   );

--- a/src/components/UI/molecules/TimeTableAddForm/TimeTableAddFormContent.tsx
+++ b/src/components/UI/molecules/TimeTableAddForm/TimeTableAddFormContent.tsx
@@ -5,7 +5,8 @@ import { SelectMenu, TimeSelectMenu, SelectMenuProps, TimeSelectMenuProps, Butto
 
 interface TimeTableAddFormContentProps {
   daySelectMenu: SelectMenuProps;
-  timeSelectMenu: TimeSelectMenuProps;
+  startTimeSelectMenu: TimeSelectMenuProps;
+  endTimeSelectMenu: TimeSelectMenuProps;
   onTimeTableFormSubmit: () => void;
 }
 
@@ -65,7 +66,12 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-const TimeTableAddFormContent = ({ daySelectMenu, timeSelectMenu, onTimeTableFormSubmit }: TimeTableAddFormContentProps): JSX.Element => {
+const TimeTableAddFormContent = ({
+  daySelectMenu,
+  startTimeSelectMenu,
+  endTimeSelectMenu,
+  onTimeTableFormSubmit,
+}: TimeTableAddFormContentProps): JSX.Element => {
   const classes = useStyles();
 
   return (
@@ -74,15 +80,15 @@ const TimeTableAddFormContent = ({ daySelectMenu, timeSelectMenu, onTimeTableFor
         <SelectMenu {...daySelectMenu} dropMenuWidth={DROP_MENU_WIDTH.DAY} />
       </div>
       <div className={classes.timeSelect}>
-        <TimeSelectMenu {...timeSelectMenu} dropMenuWidth={DROP_MENU_WIDTH.TIME} />
+        <TimeSelectMenu {...startTimeSelectMenu} dropMenuWidth={DROP_MENU_WIDTH.TIME} />
       </div>
       <div className={classes.timeSelect}>
-        <TimeSelectMenu {...timeSelectMenu} dropMenuWidth={DROP_MENU_WIDTH.TIME} />
+        <TimeSelectMenu {...endTimeSelectMenu} dropMenuWidth={DROP_MENU_WIDTH.TIME} />
       </div>
       <TextField
         required
         className={classes.timeTableNameInput}
-        id="time-tabel-name"
+        id="time-table-name"
         variant="outlined"
         InputProps={{
           placeholder: '이름을 입력해주세요. ex ) 근장',

--- a/src/components/UI/organisms/LectureList/SearchedLectureList.tsx
+++ b/src/components/UI/organisms/LectureList/SearchedLectureList.tsx
@@ -53,17 +53,17 @@ const SearchedLectureList = () => {
   };
 
   const getFilteredByDepartmentLectures = (lectures: LectureInfos[]) => {
-    if (department) return lectures.filter((lecture: LectureInfos) => lecture.department === department);
+    if (department && department !== '전체') return lectures.filter((lecture: LectureInfos) => lecture.department === department);
     return lectures;
   };
 
   const getFilteredByCreditLectures = (lectures: LectureInfos[]) => {
-    if (credit) return lectures.filter((lecture: LectureInfos) => lecture.credit === Number(credit[0]));
+    if (credit && credit !== '전체') return lectures.filter((lecture: LectureInfos) => lecture.credit === Number(credit[0]));
     return lectures;
   };
 
   const getFilteredByDayLectures = (lectures: LectureInfos[]) => {
-    if (day)
+    if (day && day !== '전체')
       return lectures.filter((lecture: LectureInfos) => {
         if (typeof lecture.lectureTimes === 'string') return false;
         if (lecture.lectureTimes) {

--- a/src/components/UI/organisms/LectureReviewWriteForm/LectureReviewWriteForm.tsx
+++ b/src/components/UI/organisms/LectureReviewWriteForm/LectureReviewWriteForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { TextField } from '@material-ui/core';
 import { Button, ButtonType, SelectMenu, LectureReviewRating } from '@/components/UI/atoms';
 import { LectureReviewHashTags } from '@/components/UI/molecules';
@@ -88,6 +88,7 @@ const BUTTON_STYLE_PROPS = { width: 160, height: 36.3, borderRadius: 16, fontSiz
 
 const LectureReviewWriteForm = (): JSX.Element => {
   const classes = useStyles();
+  const [semesterState, setSemesterState] = useState('');
 
   return (
     <div className={classes.root}>
@@ -119,6 +120,8 @@ const LectureReviewWriteForm = (): JSX.Element => {
       <div className={classes.flexArea}>
         <div className={classes.selectArea}>
           <SelectMenu
+            state={semesterState}
+            setState={setSemesterState}
             menuLabel="수강학기 선택"
             menus={MOCK_MENUS}
             dropMenuWidth={200}

--- a/src/components/pages/MainPage.tsx
+++ b/src/components/pages/MainPage.tsx
@@ -27,7 +27,7 @@ const useStyles = makeStyles({
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
-    width: '35rem',
+    width: '43rem',
   },
   marginTop: {
     width: '100%',

--- a/src/stores/LectureInfoStore.ts
+++ b/src/stores/LectureInfoStore.ts
@@ -13,6 +13,7 @@ interface LectureInfoStoreState {
   selectedStartTime: ReactiveVar<number | null>;
   selectedEndTime: ReactiveVar<number | null>;
   searchWord: ReactiveVar<string | null>;
+  isInit: ReactiveVar<boolean>;
 }
 
 class LectureInfoStore {
@@ -33,6 +34,7 @@ class LectureInfoStore {
       selectedStartTime: makeVar<number | null>(null),
       selectedEndTime: makeVar<number | null>(null),
       searchWord: makeVar<string | null>(null),
+      isInit: makeVar<boolean>(false),
     };
   }
 

--- a/src/stores/LectureInfoStore.ts
+++ b/src/stores/LectureInfoStore.ts
@@ -13,7 +13,6 @@ interface LectureInfoStoreState {
   selectedStartTime: ReactiveVar<number | null>;
   selectedEndTime: ReactiveVar<number | null>;
   searchWord: ReactiveVar<string | null>;
-  isInit: ReactiveVar<boolean>;
 }
 
 class LectureInfoStore {
@@ -34,7 +33,6 @@ class LectureInfoStore {
       selectedStartTime: makeVar<number | null>(null),
       selectedEndTime: makeVar<number | null>(null),
       searchWord: makeVar<string | null>(null),
-      isInit: makeVar<boolean>(false),
     };
   }
 


### PR DESCRIPTION
## 📑 제목

![녹화_2021_05_17_18_29_07_780](https://user-images.githubusercontent.com/46101366/118466699-0e421800-b73e-11eb-9b87-47500e2fba28.gif)

**카톡으로 말씀드렸던 상태 관련 로직 간단 요약**

각 컴포넌트에서 state로 관리를 하고 있어서 해당 값에 바로 접근할 수 없는 문제가 있었습니다.

전역 스토어를 활용해서 우선 문제를 해결했습니다.

초기화 버튼을 누르면 전역 스토어에 저장된 filter 값들이 모두 null로 초기화 되며 isInit 값이 ture로 변경됩니다.

SelectMenu 컴포넌트에는 useEffect를 추가하여 렌더링 될 때마다 isInit을 확인하여 true일 경우 컴포넌트에 존재하는 local state를 초기화 시킵니다. (선택된 value를 ''로 변경)

그 후 메뉴 박스 클릭 이벤트가 발생하면 isInit을 false로 변경합니다. (상태값이 원활하게 바뀌게 하기 위해)

TimeSelectMenu 역시 비슷한 로직으로 작성되었습니다.

가장 이상적인 방법은 state를 바로 ''로 바꿔주는 것인데 이렇게 할 수 있는 방법을 저는 생각하지 못해서 우선 위와 같이 처리했습니다. 혹시 더 좋은 방법이 있으면 알려주세요!

## 💬 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 초기화 기능
- [x] 전체 선택 옵션
- [x] 강의 목록에 정보 추가
- [x] 메인 페이지 오른쪽 탭 크기 조절 및 레이아웃 조정
- [x] LectureInfo 중복 코드 제거

## 🚧 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 나만의 시간표 부분은 아직 UI 개선이 되지 않았습니다.