### PR TITLE
장바구니 시간표 추가 기능 및 시간표 추가시 제약 조건 추가

### DIFF
--- a/src/components/UI/atoms/AlertSnackbar/AlertSnackbar.tsx
+++ b/src/components/UI/atoms/AlertSnackbar/AlertSnackbar.tsx
@@ -12,6 +12,7 @@ enum SnackbarType {
   SIGNUP_FAILED = 'SIGNUP_FAILED',
   LOGIN_SUCCESS = 'LOGIN_SUCCESS',
   LOGIN_FAILED = 'LOGIN_FAILED',
+  MY_SCHEDULE_ADD = 'MY_SCHEDULE_ADD',
 }
 
 const SNACKBAR_MESSAGE = {
@@ -21,6 +22,7 @@ const SNACKBAR_MESSAGE = {
   [SnackbarType.SIGNUP_FAILED]: '회원가입이 실패하였습니다. 다시 시도해주세요.',
   [SnackbarType.LOGIN_SUCCESS]: '정상적으로 로그인되었습니다.',
   [SnackbarType.LOGIN_FAILED]: '로그인이 실패하였습니다. 다시 시도해주세요.',
+  [SnackbarType.MY_SCHEDULE_ADD]: '나만의 시간표가 추가되었습니다.',
 };
 
 const AlertSnackbar = (): JSX.Element => {

--- a/src/components/UI/atoms/AlertSnackbar/AlertSnackbar.tsx
+++ b/src/components/UI/atoms/AlertSnackbar/AlertSnackbar.tsx
@@ -13,6 +13,10 @@ enum SnackbarType {
   LOGIN_SUCCESS = 'LOGIN_SUCCESS',
   LOGIN_FAILED = 'LOGIN_FAILED',
   MY_SCHEDULE_ADD = 'MY_SCHEDULE_ADD',
+  DUPLICATE_LECTURE_NAME = 'DUPLICATE_LECTURE_NAME',
+  DUPLICATE_LECTURE_TIME = 'DUPLICATE_LECTURE_TIME',
+  INVALID_TIME = 'INVALID_TIME',
+  NO_TIMETABLE = 'NO_TIMETABLE',
 }
 
 const SNACKBAR_MESSAGE = {
@@ -23,6 +27,10 @@ const SNACKBAR_MESSAGE = {
   [SnackbarType.LOGIN_SUCCESS]: '정상적으로 로그인되었습니다.',
   [SnackbarType.LOGIN_FAILED]: '로그인이 실패하였습니다. 다시 시도해주세요.',
   [SnackbarType.MY_SCHEDULE_ADD]: '나만의 시간표가 추가되었습니다.',
+  [SnackbarType.DUPLICATE_LECTURE_NAME]: '추가하려는 과목과 중복되는 과목이 있습니다.',
+  [SnackbarType.DUPLICATE_LECTURE_TIME]: '추가하려는 과목과 중복되는 시간이 있습니다.',
+  [SnackbarType.INVALID_TIME]: '시간이 유효하지 않습니다.',
+  [SnackbarType.NO_TIMETABLE]: '시간표를 만든 후 과목을 추가해주세요.',
 };
 
 const AlertSnackbar = (): JSX.Element => {

--- a/src/components/UI/atoms/TimeSelectMenu/TimeSelectMenu.tsx
+++ b/src/components/UI/atoms/TimeSelectMenu/TimeSelectMenu.tsx
@@ -19,8 +19,9 @@ interface TimeSelectMenuDataType {
 }
 
 interface TimeSelectMenuProps {
-  state: boolean;
-  setState: React.Dispatch<React.SetStateAction<boolean>>;
+  selected: boolean;
+  setSelected: React.Dispatch<React.SetStateAction<boolean>>;
+  setTimeValue: React.Dispatch<React.SetStateAction<number>>;
   menuLabel: string;
   dropMenuWidth?: number | string;
   onSelectMenuChange: (value: number) => void;
@@ -114,7 +115,14 @@ const MINUTE_DATAS = Array.from(range(0, 30, 30)).map((minute, idx) => ({
   type: TimeSelectMenuItemType.MINUTE,
 }));
 
-const TimeSelectMenu = ({ state, setState, menuLabel, dropMenuWidth = 'auto', onSelectMenuChange }: TimeSelectMenuProps): JSX.Element => {
+const TimeSelectMenu = ({
+  selected,
+  setSelected,
+  setTimeValue,
+  menuLabel,
+  dropMenuWidth = 'auto',
+  onSelectMenuChange,
+}: TimeSelectMenuProps): JSX.Element => {
   const [anchorEl, setAnchorEl] = React.useState<Element | null>(null);
   const [selectedAMPM, setSelectedAMPM] = useState('오전');
   const [selectedHour, setSelectedHour] = useState('01');
@@ -159,7 +167,7 @@ const TimeSelectMenu = ({ state, setState, menuLabel, dropMenuWidth = 'auto', on
 
     scrollDown(eventTarget);
     setAnchorEl(eventTarget);
-    setState(true);
+    setSelected(true);
   };
 
   const onMenuCloseListener = () => {
@@ -200,6 +208,7 @@ const TimeSelectMenu = ({ state, setState, menuLabel, dropMenuWidth = 'auto', on
     time += Number(minute);
 
     if (onSelectMenuChange) {
+      setTimeValue(time);
       onSelectMenuChange(time);
     }
   };
@@ -207,7 +216,7 @@ const TimeSelectMenu = ({ state, setState, menuLabel, dropMenuWidth = 'auto', on
   return (
     <>
       <div className={classes.root} onClick={onMenuBoxClickListener}>
-        <span className={classes.label}>{state ? selectedValue : menuLabel}</span>
+        <span className={classes.label}>{selected ? selectedValue : menuLabel}</span>
         <input type="hidden" aria-hidden="true" value={selectedValue} />
         <ExpandMoreIcon className={classes.icon} />
       </div>

--- a/src/components/UI/molecules/LectureSearchFilter/LectureSearchFilterMenu.tsx
+++ b/src/components/UI/molecules/LectureSearchFilter/LectureSearchFilterMenu.tsx
@@ -9,6 +9,8 @@ const LectureSearchFilterMenu = (): JSX.Element => {
   const [creditState, setCreditState] = useState('');
   const [startTimeState, setStartTimeState] = useState(false);
   const [endTimeState, setEndTimeState] = useState(false);
+  const [startTimeValueState, setStartTimeValueState] = useState(0);
+  const [endTimeValueState, setEndTimeValueState] = useState(0);
 
   const majorSelectMenuProps = {
     state: departmentState,
@@ -69,8 +71,9 @@ const LectureSearchFilterMenu = (): JSX.Element => {
   };
 
   const startTimeSelectMenuProps = {
-    state: startTimeState,
-    setState: setStartTimeState,
+    selected: startTimeState,
+    setSelected: setStartTimeState,
+    setTimeValue: setStartTimeValueState,
     menuLabel: '시간',
     onSelectMenuChange: (value: number) => {
       lectureInfoStore.state.searchWord(null);
@@ -82,8 +85,9 @@ const LectureSearchFilterMenu = (): JSX.Element => {
   };
 
   const endTimeSelectMenuProps = {
-    state: endTimeState,
-    setState: setEndTimeState,
+    selected: endTimeState,
+    setSelected: setEndTimeState,
+    setTimeValue: setEndTimeValueState,
     menuLabel: '시간',
     onSelectMenuChange: (value: number) => {
       lectureInfoStore.state.searchWord(null);

--- a/src/components/UI/molecules/TimeTableAddForm/TimeTableAddForm.tsx
+++ b/src/components/UI/molecules/TimeTableAddForm/TimeTableAddForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { getTimeBoundByDay } from '@/common/utils';
 import { useStores } from '@/stores';
+import { SnackbarType } from '@/components/UI/atoms';
 import { TimeTableAddFormContent } from './TimeTableAddFormContent';
 
 const TimeTableAddForm = (): JSX.Element => {
@@ -11,7 +12,7 @@ const TimeTableAddForm = (): JSX.Element => {
   const [endTimeValueState, setEndTimeValueState] = useState(0);
   const [inputState, setInputState] = useState('');
 
-  const { timeTableStore } = useStores();
+  const { timeTableStore, snackbarStore } = useStores();
 
   const daySelectMenuProps = {
     state: dayState,
@@ -70,9 +71,10 @@ const TimeTableAddForm = (): JSX.Element => {
       requiredMajor: '',
       credit: '',
     };
-
-    console.log(newCustomLecture);
-    timeTableStore.addLectureToTable(newCustomLecture);
+    if (timeTableStore.addLectureToTable(newCustomLecture)) {
+      snackbarStore.setSnackbarType(SnackbarType.MY_SCHEDULE_ADD);
+      snackbarStore.setSnackbarState(true);
+    }
   };
 
   const onInputChangeListener = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/UI/molecules/TimeTableAddForm/TimeTableAddForm.tsx
+++ b/src/components/UI/molecules/TimeTableAddForm/TimeTableAddForm.tsx
@@ -1,10 +1,17 @@
 import React, { useState } from 'react';
+import { getTimeBoundByDay } from '@/common/utils';
+import { useStores } from '@/stores';
 import { TimeTableAddFormContent } from './TimeTableAddFormContent';
 
 const TimeTableAddForm = (): JSX.Element => {
   const [dayState, setDayState] = useState('');
   const [startTimeState, setStartTimeState] = useState(false);
   const [endTimeState, setEndTimeState] = useState(false);
+  const [startTimeValueState, setStartTimeValueState] = useState(0);
+  const [endTimeValueState, setEndTimeValueState] = useState(0);
+  const [inputState, setInputState] = useState('');
+
+  const { timeTableStore } = useStores();
 
   const daySelectMenuProps = {
     state: dayState,
@@ -23,8 +30,9 @@ const TimeTableAddForm = (): JSX.Element => {
   };
 
   const startTimeSelectMenuProps = {
-    state: startTimeState,
-    setState: setStartTimeState,
+    selected: startTimeState,
+    setSelected: setStartTimeState,
+    setTimeValue: setStartTimeValueState,
     menuLabel: '시간',
     onSelectMenuChange: () => {
       console.log('시간선택');
@@ -32,8 +40,9 @@ const TimeTableAddForm = (): JSX.Element => {
   };
 
   const endTimeSelectMenuProps = {
-    state: endTimeState,
-    setState: setEndTimeState,
+    selected: endTimeState,
+    setSelected: setEndTimeState,
+    setTimeValue: setEndTimeValueState,
     menuLabel: '시간',
     onSelectMenuChange: () => {
       console.log('시간선택');
@@ -43,12 +52,41 @@ const TimeTableAddForm = (): JSX.Element => {
     alert('submit!');
   };
 
+  const onButtonClickListener = () => {
+    if (!dayState && !startTimeState && !endTimeState && inputState) return;
+    const dayBound = getTimeBoundByDay(dayState);
+
+    const newCustomLecture = {
+      id: 0,
+      code: '',
+      name: inputState,
+      divisionNumber: ' ',
+      professor: '',
+      totalStudentNumber: '',
+      department: '나만의 스케줄',
+      lectureTimes: [{ start: startTimeValueState + dayBound.start, end: endTimeValueState + dayBound.start }],
+      room: '',
+      requiredGrade: '',
+      requiredMajor: '',
+      credit: '',
+    };
+
+    console.log(newCustomLecture);
+    timeTableStore.addLectureToTable(newCustomLecture);
+  };
+
+  const onInputChangeListener = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setInputState(event.target.value);
+  };
   return (
     <TimeTableAddFormContent
       daySelectMenu={daySelectMenuProps}
       startTimeSelectMenu={startTimeSelectMenuProps}
       endTimeSelectMenu={endTimeSelectMenuProps}
       onTimeTableFormSubmit={onTimeTableFormSubmitListener}
+      inputState={inputState}
+      onInputChange={onInputChangeListener}
+      onBtnClick={onButtonClickListener}
     />
   );
 };

--- a/src/components/UI/molecules/TimeTableAddForm/TimeTableAddForm.tsx
+++ b/src/components/UI/molecules/TimeTableAddForm/TimeTableAddForm.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { getTimeBoundByDay } from '@/common/utils';
 import { useStores } from '@/stores';
-import { SnackbarType } from '@/components/UI/atoms';
 import { TimeTableAddFormContent } from './TimeTableAddFormContent';
 
 const TimeTableAddForm = (): JSX.Element => {

--- a/src/components/UI/molecules/TimeTableAddForm/TimeTableAddForm.tsx
+++ b/src/components/UI/molecules/TimeTableAddForm/TimeTableAddForm.tsx
@@ -71,10 +71,9 @@ const TimeTableAddForm = (): JSX.Element => {
       requiredMajor: '',
       credit: '',
     };
-    if (timeTableStore.addLectureToTable(newCustomLecture)) {
-      snackbarStore.setSnackbarType(SnackbarType.MY_SCHEDULE_ADD);
-      snackbarStore.setSnackbarState(true);
-    }
+
+    snackbarStore.setSnackbarType(timeTableStore.addLectureToTable(newCustomLecture));
+    snackbarStore.setSnackbarState(true);
   };
 
   const onInputChangeListener = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/UI/molecules/TimeTableAddForm/TimeTableAddFormContent.tsx
+++ b/src/components/UI/molecules/TimeTableAddForm/TimeTableAddFormContent.tsx
@@ -8,6 +8,9 @@ interface TimeTableAddFormContentProps {
   startTimeSelectMenu: TimeSelectMenuProps;
   endTimeSelectMenu: TimeSelectMenuProps;
   onTimeTableFormSubmit: () => void;
+  inputState: string;
+  onInputChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onBtnClick: () => void;
 }
 
 const DROP_MENU_WIDTH = {
@@ -71,6 +74,9 @@ const TimeTableAddFormContent = ({
   startTimeSelectMenu,
   endTimeSelectMenu,
   onTimeTableFormSubmit,
+  inputState,
+  onInputChange,
+  onBtnClick,
 }: TimeTableAddFormContentProps): JSX.Element => {
   const classes = useStyles();
 
@@ -86,6 +92,7 @@ const TimeTableAddFormContent = ({
         <TimeSelectMenu {...endTimeSelectMenu} dropMenuWidth={DROP_MENU_WIDTH.TIME} />
       </div>
       <TextField
+        value={inputState}
         required
         className={classes.timeTableNameInput}
         id="time-table-name"
@@ -93,8 +100,9 @@ const TimeTableAddFormContent = ({
         InputProps={{
           placeholder: '이름을 입력해주세요. ex ) 근장',
         }}
+        onChange={onInputChange}
       />
-      <Button btnType={ButtonType.primary} style={BUTTON_STYLE_PROPS}>
+      <Button btnType={ButtonType.primary} style={BUTTON_STYLE_PROPS} onClick={onBtnClick}>
         추 가
       </Button>
     </form>

--- a/src/components/UI/organisms/LectureList/SearchedLectureList.tsx
+++ b/src/components/UI/organisms/LectureList/SearchedLectureList.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable consistent-return */
 /* eslint-disable @typescript-eslint/no-shadow */
 import React from 'react';
-import { SnackbarType } from '@/components/UI/atoms';
 import { LectureInfos, LectureListContent } from '@/components/UI/molecules';
 import { useStores } from '@/stores';
 import { isString } from '@/common/utils/typeCheck';

--- a/src/components/UI/organisms/LectureList/SearchedLectureList.tsx
+++ b/src/components/UI/organisms/LectureList/SearchedLectureList.tsx
@@ -103,8 +103,7 @@ const SearchedLectureList = () => {
   const onLectureSearchDoubleClickListener = (lectureInfos: LectureInfos) => {
     if (isString(lectureInfos.lectureTimes)) return;
 
-    timeTableStore.addLectureToTable(lectureInfos);
-    snackbarStore.setSnackbarType(SnackbarType.ADD_SUCCESS);
+    snackbarStore.setSnackbarType(timeTableStore.addLectureToTable(lectureInfos));
     snackbarStore.setSnackbarState(true);
   };
 

--- a/src/stores/TimeTableStore.ts
+++ b/src/stores/TimeTableStore.ts
@@ -98,8 +98,9 @@ class TimeTableStore {
     return selectedTabLectures()[selectedTabIdx() - 1].every((curr) => curr.name !== lectureName);
   }
 
-  checkTimeBound(lectureTimes: TimeTypes[]): boolean {
+  checkTimeBound(lectureTimes: TimeTypes[] | string): boolean {
     const { selectedTabIdx } = this.state;
+    if (typeof lectureTimes === 'string') return false;
     return lectureTimes.every((lectureTime) => lectureTime.start < lectureTime.end && lectureTime.start % 1440 >= 540);
   }
 
@@ -118,12 +119,12 @@ class TimeTableStore {
     });
   }
 
-  addLectureToTable(input: LectureInfos): boolean {
+  addLectureToTable(input: LectureInfos): SnackbarType {
     const { selectedTabIdx, selectedTabLectures } = this.state;
-    if (!selectedTabIdx()) return false;
-    if (!this.checkDuplicateLectureName(input.name)) return false;
-    if (!this.checkTimeBound) return false;
-    if (!this.checkDuplicateLectureTime(input.lectureTimes)) return false;
+    if (!selectedTabIdx()) return SnackbarType.NO_TIMETABLE;
+    if (!this.checkDuplicateLectureName(input.name)) return SnackbarType.DUPLICATE_LECTURE_NAME;
+    if (!this.checkTimeBound(input.lectureTimes)) return SnackbarType.INVALID_TIME;
+    if (!this.checkDuplicateLectureTime(input.lectureTimes)) return SnackbarType.DUPLICATE_LECTURE_TIME;
     const inputWithColor = { ...input, color: this.getColor() };
     const newLecture = [...selectedTabLectures()[selectedTabIdx() - 1], inputWithColor];
     const newLectures = selectedTabLectures().map((elem, idx) => {
@@ -132,7 +133,7 @@ class TimeTableStore {
     });
     this.setNextColor();
     selectedTabLectures(newLectures);
-    return true;
+    return SnackbarType.ADD_SUCCESS;
   }
 
   removeLectureFromTable(input: string): void {

--- a/src/stores/TimeTableStore.ts
+++ b/src/stores/TimeTableStore.ts
@@ -1,6 +1,6 @@
 import { makeVar, ReactiveVar } from '@apollo/client';
 import { RootStore } from '@/stores';
-import { LectureInfos } from '@/components/UI/molecules';
+import { LectureInfos, TimeTypes } from '@/components/UI/molecules';
 
 interface TableInfo {
   name: string;
@@ -92,11 +92,21 @@ class TimeTableStore {
     this.selectTab(nextSelectedTab);
   }
 
+  checkDuplicateLectureName(lectureName: string): boolean {
+    const { selectedTabIdx, selectedTabLectures } = this.state;
+    return selectedTabLectures()[selectedTabIdx() - 1].every((curr) => curr.name !== lectureName);
+  }
+
+  checkTimeBound(lectureTimes: TimeTypes[]): boolean {
+    const { selectedTabIdx } = this.state;
+    return lectureTimes.every((lectureTime) => lectureTime.start < lectureTime.end && lectureTime.start % 1440 >= 540);
+  }
+
   addLectureToTable(input: LectureInfos): boolean {
     const { selectedTabIdx, selectedTabLectures } = this.state;
     if (!selectedTabIdx()) return false;
-    const isNoDuplicateLecture = selectedTabLectures()[selectedTabIdx() - 1].every((curr) => curr.name !== input.name);
-    if (!isNoDuplicateLecture) return false;
+    if (!this.checkDuplicateLectureName(input.name)) return false;
+    if (!this.checkTimeBound) return false;
     const inputWithColor = { ...input, color: this.getColor() };
     const newLecture = [...selectedTabLectures()[selectedTabIdx() - 1], inputWithColor];
     const newLectures = selectedTabLectures().map((elem, idx) => {

--- a/src/stores/TimeTableStore.ts
+++ b/src/stores/TimeTableStore.ts
@@ -92,11 +92,11 @@ class TimeTableStore {
     this.selectTab(nextSelectedTab);
   }
 
-  addLectureToTable(input: LectureInfos): void {
+  addLectureToTable(input: LectureInfos): boolean {
     const { selectedTabIdx, selectedTabLectures } = this.state;
-    if (!selectedTabIdx()) return;
+    if (!selectedTabIdx()) return false;
     const isNoDuplicateLecture = selectedTabLectures()[selectedTabIdx() - 1].every((curr) => curr.name !== input.name);
-    if (!isNoDuplicateLecture) return;
+    if (!isNoDuplicateLecture) return false;
     const inputWithColor = { ...input, color: this.getColor() };
     const newLecture = [...selectedTabLectures()[selectedTabIdx() - 1], inputWithColor];
     const newLectures = selectedTabLectures().map((elem, idx) => {
@@ -105,6 +105,7 @@ class TimeTableStore {
     });
     this.setNextColor();
     selectedTabLectures(newLectures);
+    return true;
   }
 
   removeLectureFromTable(input: string): void {


### PR DESCRIPTION
## 📑 제목

![녹화_2021_05_19_23_23_45_900](https://user-images.githubusercontent.com/46101366/118829959-8d2f8000-b8f9-11eb-84a4-1a9d11008d73.gif)



## 💬 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 장바구니 시간표 추가 기능
- [x] 시간표 추가시 제약 조건 추가 및 alert 종류 추가
  - 유효하지 않은 시간(end가 start보다 앞선 경우, 오전 9시 이전인 경우)
  - 중복되는 과목
  - 중복되는 시간
  - 시간표를 안 만들고 추가한 경우 => 추후 삭제 될 수도 있음
- [x] TimeSelectMenu 리팩토링
  - 이전 PR에서 isSelected를 상위 컴포넌트에서 전달하게 수정했으나 값을 갖고 있는 것이 좋겠다고 판단하여 시간 값에 대한 state 역시 상위 컴포넌트에서 전달하는 방식으로 수정했습니다.
  - 한 가지 걸리는 점은 Filter 작업을 할 때는 시간 값이 필요하지 않기에 값만 전달하고 사용되지 않고 있는데 이 부분에 대해 우진님과 이야기 해보고 어떤 구조로 가져갈지 결정하면 좋을 듯 합니다.

## 🚧 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점
