### PR TITLE
회원가입 폼 중복체크 로직 수정 작업

### DIFF
--- a/src/common/hooks/useInputForm.ts
+++ b/src/common/hooks/useInputForm.ts
@@ -14,6 +14,7 @@ enum InputNameType {
 interface Option {
   validation?: boolean;
   timeout?: number;
+  callback?: Function;
 }
 
 interface InputUtility {
@@ -33,7 +34,7 @@ const ERRORS = {
 };
 
 function useInputForm<T>(initInputState: T, options: Option = INIT_OPTIONS): [T, () => void, InputUtility] {
-  const { validation, timeout } = { ...INIT_OPTIONS, ...options };
+  const { validation, timeout, callback } = { ...INIT_OPTIONS, ...options };
 
   const createValidState = () => {
     if (validation) {
@@ -58,6 +59,10 @@ function useInputForm<T>(initInputState: T, options: Option = INIT_OPTIONS): [T,
 
   const onChangeListener = debounce((e: React.ChangeEvent<HTMLInputElement>) => {
     const { value, name } = e.target;
+
+    if (callback) {
+      callback(name);
+    }
 
     setInputs({ ...inputs, [name]: value });
     if (valids) {

--- a/src/components/UI/atoms/AlertSnackbar/AlertSnackbar.tsx
+++ b/src/components/UI/atoms/AlertSnackbar/AlertSnackbar.tsx
@@ -18,6 +18,7 @@ enum SnackbarType {
   DUPLICATE_LECTURE_TIME = 'DUPLICATE_LECTURE_TIME',
   INVALID_TIME = 'INVALID_TIME',
   NO_TIMETABLE = 'NO_TIMETABLE',
+  SIGNUP_DUPLICATED_FAILED = 'SIGNUP_DUPLICATED_FAILED',
 }
 
 const SNACKBAR_MESSAGE = {
@@ -33,6 +34,7 @@ const SNACKBAR_MESSAGE = {
   [SnackbarType.DUPLICATE_LECTURE_TIME]: '추가하려는 과목과 중복되는 시간이 있습니다.',
   [SnackbarType.INVALID_TIME]: '시간이 유효하지 않습니다.',
   [SnackbarType.NO_TIMETABLE]: '시간표를 만든 후 과목을 추가해주세요.',
+  [SnackbarType.SIGNUP_DUPLICATED_FAILED]: '중복체크가 실패하였습니다. 잠시 후 다시 시도해주세요.',
 };
 
 const AlertSnackbar = (): JSX.Element => {

--- a/src/components/UI/molecules/SignUpModalContent/SignUpModalContent.tsx
+++ b/src/components/UI/molecules/SignUpModalContent/SignUpModalContent.tsx
@@ -212,13 +212,13 @@ const SignUpModalContent = ({
   };
 
   const checkEmailInputError = (): boolean => {
-    const { duplicated, loading, email } = emailCheckInfo;
-    return !!email && (!isValidEmail || duplicated || loading);
+    const { duplicated, loading, email, called } = emailCheckInfo;
+    return !!email && (!isValidEmail || duplicated || loading || !called);
   };
 
   const checkNicknameInputError = (): boolean => {
-    const { duplicated, loading, nickname } = nicknameCheckInfo;
-    return !!nickname && (!isValidNickname || duplicated || loading);
+    const { duplicated, loading, nickname, called } = nicknameCheckInfo;
+    return !!nickname && (!isValidNickname || duplicated || loading || !called);
   };
 
   const checkEmailCheckBtnDisabled = (): boolean => {

--- a/src/components/UI/organisms/ModalPopup/SignUpModalPopup.tsx
+++ b/src/components/UI/organisms/ModalPopup/SignUpModalPopup.tsx
@@ -51,11 +51,16 @@ const SignUpModalPopup = ({ modalOpen, onModalAreaClose }: SignUpModalPopupProps
     },
   });
 
+  const onCheckDuplicatedError = () => {
+    snackbarStore.showCheckDuplicatedFailedMsg();
+  };
+
   const [
     getMemberDuplicatedByEmail,
     { data: emailDulicatedData, called: emailDulicatedCalled, loading: emailDulicatedLoading },
   ] = useLazyQuery<GetMemberDuplicatedByEmail>(MEMBER_DUPLICATED_BY_EMAIL, {
     fetchPolicy: 'no-cache',
+    onError: onCheckDuplicatedError,
   });
 
   const [
@@ -63,6 +68,7 @@ const SignUpModalPopup = ({ modalOpen, onModalAreaClose }: SignUpModalPopupProps
     { data: nicknameDulicatedData, called: nicknameDulicatedCalled, loading: nicknameDulicatedLoading },
   ] = useLazyQuery<GetMemberDuplicatedByNickname>(MEMBER_DUPLICATED_BY_NICKNAME, {
     fetchPolicy: 'no-cache',
+    onError: onCheckDuplicatedError,
   });
 
   const onCheckDuplicatedBtnClickListener = (type: string) => {

--- a/src/components/UI/organisms/ModalPopup/SignUpModalPopup.tsx
+++ b/src/components/UI/organisms/ModalPopup/SignUpModalPopup.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import { ModalPopupArea, SignUpModalContent } from '@/components/UI/molecules';
 import { useMutation, useLazyQuery } from '@apollo/client';
 import { SIGN_UP, MEMBER_DUPLICATED_BY_EMAIL, MEMBER_DUPLICATED_BY_NICKNAME } from '@/queries';
@@ -35,8 +35,20 @@ const INIT_INPUTS_STATE = {
 };
 
 const SignUpModalPopup = ({ modalOpen, onModalAreaClose }: SignUpModalPopupProps): JSX.Element => {
+  const emailDulicatedCalled = useRef(false);
+  const nicknameDulicatedCalled = useRef(false);
+
   const [inputs, onInputChange, { reset, isEmpty, valids, isValid }] = useInputForm<InputState>(INIT_INPUTS_STATE, {
     validation: true,
+    callback: (name: string) => {
+      if (name === DuplicateCheckingType.email) {
+        emailDulicatedCalled.current = false;
+      }
+
+      if (name === DuplicateCheckingType.nickname) {
+        nicknameDulicatedCalled.current = false;
+      }
+    },
   });
   const { email, password, name, nickname, grade, major } = inputs;
 
@@ -55,17 +67,17 @@ const SignUpModalPopup = ({ modalOpen, onModalAreaClose }: SignUpModalPopupProps
     snackbarStore.showCheckDuplicatedFailedMsg();
   };
 
-  const [
-    getMemberDuplicatedByEmail,
-    { data: emailDulicatedData, called: emailDulicatedCalled, loading: emailDulicatedLoading },
-  ] = useLazyQuery<GetMemberDuplicatedByEmail>(MEMBER_DUPLICATED_BY_EMAIL, {
-    fetchPolicy: 'no-cache',
-    onError: onCheckDuplicatedError,
-  });
+  const [getMemberDuplicatedByEmail, { data: emailDulicatedData, loading: emailDulicatedLoading }] = useLazyQuery<GetMemberDuplicatedByEmail>(
+    MEMBER_DUPLICATED_BY_EMAIL,
+    {
+      fetchPolicy: 'no-cache',
+      onError: onCheckDuplicatedError,
+    },
+  );
 
   const [
     getMemberDuplicatedByNickname,
-    { data: nicknameDulicatedData, called: nicknameDulicatedCalled, loading: nicknameDulicatedLoading },
+    { data: nicknameDulicatedData, loading: nicknameDulicatedLoading },
   ] = useLazyQuery<GetMemberDuplicatedByNickname>(MEMBER_DUPLICATED_BY_NICKNAME, {
     fetchPolicy: 'no-cache',
     onError: onCheckDuplicatedError,
@@ -73,26 +85,14 @@ const SignUpModalPopup = ({ modalOpen, onModalAreaClose }: SignUpModalPopupProps
 
   const onCheckDuplicatedBtnClickListener = (type: string) => {
     if (type === DuplicateCheckingType.email) {
+      emailDulicatedCalled.current = true;
       getMemberDuplicatedByEmail({ variables: { email } });
     }
 
     if (type === DuplicateCheckingType.nickname) {
+      nicknameDulicatedCalled.current = true;
       getMemberDuplicatedByNickname({ variables: { nickname } });
     }
-  };
-
-  const checkEmailDuplicated = (): boolean => {
-    if (!emailDulicatedData) {
-      return true;
-    }
-    return emailDulicatedData.memberDuplicatedByEmail;
-  };
-
-  const checkNicknameDuplicated = (): boolean => {
-    if (!nicknameDulicatedData) {
-      return true;
-    }
-    return nicknameDulicatedData.memberDuplicatedByNickname;
   };
 
   const onMoveLoginBtnClickListener = () => {
@@ -110,8 +110,26 @@ const SignUpModalPopup = ({ modalOpen, onModalAreaClose }: SignUpModalPopupProps
     onModalAreaClose();
   };
 
+  const checkEmailDuplicated = (): boolean => {
+    if (!emailDulicatedData) return true;
+    return emailDulicatedData.memberDuplicatedByEmail;
+  };
+
+  const checkNicknameDuplicated = (): boolean => {
+    if (!nicknameDulicatedData) return true;
+    return nicknameDulicatedData.memberDuplicatedByNickname;
+  };
+
+  const checkEmailInfo = (): boolean => {
+    return !emailDulicatedLoading && !checkEmailDuplicated() && emailDulicatedCalled.current;
+  };
+
+  const checkNicknameInfo = (): boolean => {
+    return !nicknameDulicatedLoading && !checkNicknameDuplicated() && nicknameDulicatedCalled.current;
+  };
+
   const checkSignupDisabled = (): boolean => {
-    return !(!isEmpty && isValid && !emailDulicatedLoading && !checkEmailDuplicated() && !nicknameDulicatedLoading && !checkNicknameDuplicated());
+    return !(!isEmpty && isValid && checkEmailInfo() && checkNicknameInfo());
   };
 
   return (
@@ -119,8 +137,13 @@ const SignUpModalPopup = ({ modalOpen, onModalAreaClose }: SignUpModalPopupProps
       <SignUpModalContent
         valid={valids}
         selectValue={{ gradeValue: grade, majorValue: major }}
-        emailCheckInfo={{ email, duplicated: checkEmailDuplicated(), called: emailDulicatedCalled, loading: emailDulicatedLoading }}
-        nicknameCheckInfo={{ nickname, duplicated: checkNicknameDuplicated(), called: nicknameDulicatedCalled, loading: nicknameDulicatedLoading }}
+        emailCheckInfo={{ email, duplicated: checkEmailDuplicated(), called: emailDulicatedCalled.current, loading: emailDulicatedLoading }}
+        nicknameCheckInfo={{
+          nickname,
+          duplicated: checkNicknameDuplicated(),
+          called: nicknameDulicatedCalled.current,
+          loading: nicknameDulicatedLoading,
+        }}
         isSignupDisabled={checkSignupDisabled()}
         onInputChange={onInputChange}
         onSignupBtnClick={onSignUpBtnClickListener}

--- a/src/stores/SnackbarStore.ts
+++ b/src/stores/SnackbarStore.ts
@@ -70,6 +70,11 @@ class SnackbarStore {
     this.setSnackbarType(SnackbarType.NAV_FAILED);
     this.setSnackbarState(true);
   }
+
+  showCheckDuplicatedFailedMsg(): void {
+    this.setSnackbarType(SnackbarType.SIGNUP_DUPLICATED_FAILED);
+    this.setSnackbarState(true);
+  }
 }
 
 export default SnackbarStore;


### PR DESCRIPTION
## 📑 제목

#75 회원가입 폼 중복체크 로직 수정 작업
- #122 이메일, 닉네임 중복체크 시 발생하는 버그 수정으로 인해 중복체크 로직을 수정함

## 💬 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 이메일, 닉네임 중복체크 쿼리 실패시 AlertSnackbar 메세지 띄우는 로직 추가
- [x] 이메일, 닉네임 중복체크에 따른 적절한 error 표시 및 helperText를 표시하고, 회원가입 버튼을 활성화하도록 코드 수정
- [x] 기타 작업사항
  - AlertSnackbar 회원가입 폼 중복체크 실패 메세지 추가
  - useInputForm hook의 onChange 디바운싱 함수에서 option으로 전달받은 callback 함수를 실행할 수 있도록 코드 수정

> 회원가입 폼 수정 결과

![ezgif com-gif-maker (45)](https://user-images.githubusercontent.com/32856129/118984507-86b40d80-b9b8-11eb-8104-f5207b6fe636.gif)

## 🚧 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 회원가입 폼 코드를 최대한 간결하게 유지하고 싶었는데, hook을 사용하면 할 수록 코드가 복잡해지네요! 추후에 리팩토링을 해야겠습니다 :) 드디어 회원가입 폼을 마무리했네용!