### PR TITLE
강의 목록 검색 Throttling 적용

### DIFF
--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -4,3 +4,4 @@ export { default as debounce } from './debounce';
 export * from './typeCheck';
 export * from './unit';
 export * from './getTimeBound';
+export { default as throttle } from './throttle';

--- a/src/common/utils/throttle.ts
+++ b/src/common/utils/throttle.ts
@@ -1,0 +1,17 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-this-alias */
+const throttle = (func: Function, wait: number): (() => void) => {
+  let timeout: NodeJS.Timeout | null = null;
+
+  return (...args: any[]): void => {
+    const context = this;
+    if (!timeout) {
+      timeout = setTimeout(() => {
+        timeout = null;
+        func.apply(context, args);
+      }, wait);
+    }
+  };
+};
+
+export default throttle;

--- a/src/components/UI/molecules/ReviewSearchSection/ReviewSearchSection.tsx
+++ b/src/components/UI/molecules/ReviewSearchSection/ReviewSearchSection.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { FormControlLabel } from '@material-ui/core';
 import CheckBox from '@material-ui/core/Checkbox';
 import { SelectMenu } from '@/components/UI/atoms';
-import { SearchBar } from '@/components/UI/molecules';
+import { ReviewSearchBar } from '@/components/UI/molecules';
 
 const ReviewSearchSection = (): JSX.Element => {
   const [isChecked, setIsChecked] = useState(false);
@@ -27,7 +27,7 @@ const ReviewSearchSection = (): JSX.Element => {
   };
   return (
     <>
-      <SearchBar width="60%" />
+      <ReviewSearchBar searchBarProp={{ width: '60%' }} />
       <FormControlLabel
         control={<CheckBox checked={isChecked} onChange={onCheckBoxChangeHandler} name="isMine" color="primary" />}
         label="내가 쓴 글 보기"

--- a/src/components/UI/molecules/SearchBar/LectureSearchBar.tsx
+++ b/src/components/UI/molecules/SearchBar/LectureSearchBar.tsx
@@ -8,7 +8,7 @@ const LectureSearchBar = (): JSX.Element => {
 
   const onSearchBarChangeListener = throttle((e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;
-    lectureInfoStore.state.searchWord(value);
+    lectureInfoStore.setSearchWord(value);
   }, 500);
 
   return <SearchBar onSearchBarChange={onSearchBarChangeListener} />;

--- a/src/components/UI/molecules/SearchBar/LectureSearchBar.tsx
+++ b/src/components/UI/molecules/SearchBar/LectureSearchBar.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { useStores } from '@/stores';
+import { throttle } from '@/common/utils';
+import { SearchBar } from './SearchBar';
+
+const LectureSearchBar = (): JSX.Element => {
+  const { lectureInfoStore } = useStores();
+
+  const onSearchBarChangeListener = throttle((e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    lectureInfoStore.state.searchWord(value);
+  }, 500);
+
+  return <SearchBar onSearchBarChange={onSearchBarChangeListener} />;
+};
+
+export { LectureSearchBar };

--- a/src/components/UI/molecules/SearchBar/ReviewSearchBar.tsx
+++ b/src/components/UI/molecules/SearchBar/ReviewSearchBar.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { throttle } from '@/common/utils';
+import { SearchBar, SearchBarProps } from './SearchBar';
+
+interface ReviewSearchBarProps {
+  searchBarProp?: SearchBarProps;
+}
+
+const ReviewSearchBar = ({ searchBarProp }: ReviewSearchBarProps): JSX.Element => {
+  const onSearchBarChangeListener = throttle((e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+  }, 500);
+
+  return <SearchBar {...searchBarProp} onSearchBarChange={onSearchBarChangeListener} />;
+};
+
+export { ReviewSearchBar };

--- a/src/components/UI/molecules/SearchBar/SearchBar.stories.tsx
+++ b/src/components/UI/molecules/SearchBar/SearchBar.stories.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { withKnobs } from '@storybook/addon-knobs';
 import { Story, Meta } from '@storybook/react/types-6-0';
-import { SearchBar } from '@/components/UI/molecules';
+import { action } from '@storybook/addon-actions';
+import { SearchBar, SearchBarProps } from '@/components/UI/molecules';
 
 export default {
   title: 'molecules/SearchBar',
@@ -9,6 +10,9 @@ export default {
   decorators: [withKnobs],
 } as Meta;
 
-const Template: Story = (args) => <SearchBar {...args} />;
+const Template: Story<SearchBarProps> = (args) => <SearchBar {...args} />;
 
 export const Default = Template.bind({});
+Default.args = {
+  onSearchBarChange: action('onChange'),
+};

--- a/src/components/UI/molecules/SearchBar/SearchBar.tsx
+++ b/src/components/UI/molecules/SearchBar/SearchBar.tsx
@@ -1,11 +1,10 @@
-import React, { useRef } from 'react';
-import { InputBase } from '@material-ui/core';
+import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { Search } from '@material-ui/icons';
-import { useStores } from '@/stores';
 
 interface SearchBarProps {
   width?: string;
+  onSearchBarChange?: () => void;
 }
 
 interface CSSProps {
@@ -14,12 +13,12 @@ interface CSSProps {
 
 const useStyles = makeStyles((theme) => ({
   root: ({ width }: CSSProps) => ({
+    borderRadius: '1.25rem',
+    backgroundColor: `${theme.palette.grey[100]}`,
     display: 'flex',
     width: `${width}`,
     boxSizing: 'border-box',
-    borderRadius: '10rem',
-    padding: `0.25rem 1.5rem`,
-    backgroundColor: `${theme.palette.grey[100]}`,
+    padding: `0.4rem 1.5rem`,
     alignItems: 'center',
     justifyContent: 'space-between',
   }),
@@ -27,33 +26,29 @@ const useStyles = makeStyles((theme) => ({
     width: '85%',
     border: 'none',
     backgroundColor: 'rgba(0, 0, 0, 0)',
+    fontSize: '0.9rem',
+
     '&:focus': {
       outline: 'none',
     },
-    fontSize: '0.9rem',
   },
   icon: {
     color: `${theme.palette.grey[500]}`,
+
     '&:hover': {
       cursor: 'pointer',
     },
   },
 }));
 
-const SearchBar = ({ width = '100%' }: SearchBarProps): JSX.Element => {
+const SearchBar = ({ onSearchBarChange, width = '100%' }: SearchBarProps): JSX.Element => {
   const classes = useStyles({ width });
-  const inputElem = useRef<HTMLInputElement>(null);
-  const { lectureInfoStore } = useStores();
-  const onLectureSearchListener = (event: any) => {
-    event.preventDefault();
-    lectureInfoStore.state.searchWord(inputElem.current?.value);
-    if (inputElem.current) inputElem.current.value = '';
-  };
+
   return (
-    <form className={classes.root} onSubmit={onLectureSearchListener}>
-      <input ref={inputElem} className={classes.input} placeholder="검색어를 입력하세요." />
-      <Search className={classes.icon} onClick={onLectureSearchListener} />
-    </form>
+    <div className={classes.root}>
+      <input className={classes.input} name="searchWord" placeholder="검색어를 입력하세요." onChange={onSearchBarChange} />
+      <Search className={classes.icon} />
+    </div>
   );
 };
 

--- a/src/components/UI/molecules/index.ts
+++ b/src/components/UI/molecules/index.ts
@@ -2,6 +2,7 @@ export { Timetable } from './Timetable/Timetable';
 export type { TimetableProps } from './Timetable/Timetable';
 export { Notice } from './Notice/Notice';
 export { LectureSearchBar } from './SearchBar/LectureSearchBar';
+export { ReviewSearchBar } from './SearchBar/ReviewSearchBar';
 export { LectureInfo } from './LectureInfo/LectureInfo';
 export type { LectureInfoProps, LectureInfos, TimeTypes } from './LectureInfo/LectureInfo';
 export { ModalPopupArea } from './ModalPopupArea/ModalPopupArea';

--- a/src/components/UI/molecules/index.ts
+++ b/src/components/UI/molecules/index.ts
@@ -1,7 +1,7 @@
 export { Timetable } from './Timetable/Timetable';
 export type { TimetableProps } from './Timetable/Timetable';
 export { Notice } from './Notice/Notice';
-export { SearchBar } from './SearchBar/SearchBar';
+export { LectureSearchBar } from './SearchBar/LectureSearchBar';
 export { LectureInfo } from './LectureInfo/LectureInfo';
 export type { LectureInfoProps, LectureInfos, TimeTypes } from './LectureInfo/LectureInfo';
 export { ModalPopupArea } from './ModalPopupArea/ModalPopupArea';

--- a/src/components/UI/organisms/ModalPopup/SignUpModalPopup.tsx
+++ b/src/components/UI/organisms/ModalPopup/SignUpModalPopup.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef } from 'react';
 import { ModalPopupArea, SignUpModalContent } from '@/components/UI/molecules';
 import { useMutation, useLazyQuery } from '@apollo/client';
 import { SIGN_UP, MEMBER_DUPLICATED_BY_EMAIL, MEMBER_DUPLICATED_BY_NICKNAME } from '@/queries';

--- a/src/components/pages/MainPage.tsx
+++ b/src/components/pages/MainPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { AlertSnackbar } from '@/components/UI/atoms';
-import { Timetable, Notice, SearchBar, SubTitle, LectureSearchFilterMenu, TimeTableAddForm } from '@/components/UI/molecules';
+import { Timetable, Notice, LectureSearchBar, SubTitle, LectureSearchFilterMenu, TimeTableAddForm } from '@/components/UI/molecules';
 import { makeStyles } from '@material-ui/core';
 import { LectureList, ModalPopup, TimeTableMenu, Footer } from '@/components/UI/organisms';
 
@@ -49,7 +49,7 @@ const MainPage = (): JSX.Element => {
           <div className={classes.right}>
             <SubTitle>강의 찾기</SubTitle>
             <div className={classes.marginTop}>
-              <SearchBar />
+              <LectureSearchBar />
             </div>
             <LectureSearchFilterMenu />
             <LectureList />

--- a/src/reset.css
+++ b/src/reset.css
@@ -84,6 +84,6 @@ table {
 	border-spacing: 0;
 }
 
-textarea{
+textarea, input{
 	font-family: AppleSDGothicNeo;
 }

--- a/src/stores/LectureInfoStore.ts
+++ b/src/stores/LectureInfoStore.ts
@@ -38,8 +38,18 @@ class LectureInfoStore {
 
   getSameLectures(): LectureInfos[] {
     const { lectures, selectedLecture } = this.state;
+
     if (selectedLecture() === null) return [];
+
     return lectures().filter((lecture) => lecture.code === selectedLecture()?.code);
+  }
+
+  setSearchWord(newSearchWord: string): void {
+    const { searchWord } = this.state;
+
+    if (newSearchWord === searchWord()) return;
+
+    searchWord(newSearchWord);
   }
 }
 


### PR DESCRIPTION
## 📑 제목

#126 강의 목록 검색 Throttling 적용


## 💬 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] throttle 유틸 함수 제작
  - 함수를 입력받아 Throttling이 적용된 함수를 리턴해주는 유틸 함수 제작
- [x] SearchBar 컴포넌트 리팩토링
  - SearchBar 컴포넌트가 메인 페이지, 강의 후기 페이지에서도 사용되므로, 비즈니스 로직을 분리하여 LectureSearchBar, ReviewSearchBar  컴포넌트 제작
  - Throttling을 적용하여 타이핑하면서 검색이 되도록 변경해야하므로, 기존 submit, click 이벤트를 제거하고 onChange 이벤트를 활용하도록 수정
- [x] 검색창 Throttling 적용
  - 메인페이지 강의 검색창, 강의 후기 페이지 후기 검색창에 Throttling 적용하여 타이핑시 500ms마다 검색을 수행하도록 구현
- [x] LectureInfoStore 검색어 상태 변경 메소드 정의

> 구현 결과

![ezgif com-gif-maker (46)](https://user-images.githubusercontent.com/32856129/119159349-1679ba80-ba92-11eb-816d-b9faff8b095d.gif)

## 🚧 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 검색창에 throttling을 적용하는 부분을 hook으로 분리할까 생각을 하던 와중에 특별히 상태값을 사용하지도 않고, 재사용되는 코드가 적어서 일단 보류했습니다 :)
- 추후에 데이터가 초기 강의목록 데이터가 로딩되지 않은 상태에서 검색창에 검색을 시도하는 경우에 대한 예외처리가 필요해보입니다. 검색창뿐만 아니라 다른 인터렉션 요소들도 예외처리가 필요한데, 이전에 이야기나눈데로 메인페이지에서 초기 로딩창제작이 깔끔할 것 같기도 합니다 :)