### PR TITLE
비밀번호 찾기 모달 폼 제작

### DIFF
--- a/src/components/UI/molecules/FindModalContent/FindModalContent.stories.tsx
+++ b/src/components/UI/molecules/FindModalContent/FindModalContent.stories.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import { action } from '@storybook/addon-actions';
+import { withStoryBox } from '@/components/HOC';
+import { FindModalContent, FindModalType, FindModalContentProps } from './FindModalContent';
+
+export default {
+  title: 'molecules/FindModalContent',
+  component: FindModalContent,
+  decorators: [withKnobs],
+} as Meta;
+
+const Template: Story<FindModalContentProps> = (args) => {
+  const FindModalContentStory = withStoryBox(args, 700)(FindModalContent);
+  return <FindModalContentStory />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  modalType: FindModalType.FIND_MODAL,
+  valid: [true, true],
+  isFindDisabled: true,
+  onFindBtnClick: action('onClick'),
+  onInputChange: action('onChange'),
+};

--- a/src/components/UI/molecules/FindModalContent/FindModalContent.tsx
+++ b/src/components/UI/molecules/FindModalContent/FindModalContent.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { DialogTitle, DialogContent, DialogActions, TextField, Typography } from '@material-ui/core';
+import { Button, ButtonType } from '@/components/UI/atoms';
+import { makeStyles } from '@material-ui/core/styles';
+
+enum FindModalType {
+  FIND_MODAL = 'FIND_MODAL',
+}
+
+interface FindModalContentProps {
+  valid: boolean[];
+  isFindDisabled: boolean;
+  onFindBtnClick: () => void;
+  onInputChange: () => void;
+}
+
+const useStyles = makeStyles((theme) => ({
+  title: {
+    display: 'flex',
+    justifyContent: 'center',
+    fontSize: '1.7rem',
+    color: theme.palette.primary.main,
+  },
+  dialogContentRoot: {
+    paddingTop: 0,
+
+    '&.MuiDialogContent-root': {
+      overflow: 'hidden',
+    },
+  },
+  dialogActionRoot: {
+    display: 'flex',
+    flexDirection: 'column',
+
+    '&.MuiDialogActions-root': {
+      padding: '1rem 1.5rem',
+    },
+  },
+  msgArea: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    marginBottom: '20px',
+
+    '& > p': {
+      marginBottom: '3px',
+      fontSize: '13px',
+
+      '&:last-of-type': {
+        marginBottom: 0,
+      },
+    },
+  },
+  linkTextArea: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    width: '100%',
+    paddingTop: '1rem',
+    margin: '0 !important',
+  },
+  linkText: {
+    color: theme.palette.grey[600],
+  },
+}));
+
+const HELPER_TEXT = {
+  EMAIL: {
+    DEFAULT: '아이디는 한기대 포털 아이디입니다. @koreatech.ac.kr은 빼고 입력해주세요.',
+    ERROR: '한기대 포털 아이디는 1자리 이상 12자리 이하 / 영소문자, 숫자, _ 로만 조합되어야합니다. ',
+  },
+  NAME: {
+    DEFAULT: '이름을 입력해주세요.',
+    ERROR: '이름은 최소 2자 이상 / 한글로만 조합되어야합니다.',
+  },
+};
+
+const LOGIN_BUTTON_STYLE_PROPS = { width: 192, height: 35.2, borderRadius: 4, fontSize: 16 };
+
+const FindModalContent = ({ valid, isFindDisabled, onInputChange, onFindBtnClick }: FindModalContentProps): JSX.Element => {
+  const classes = useStyles();
+  const [isValidEmail, isValidName] = valid;
+
+  return (
+    <>
+      <DialogTitle className={classes.title} id="login-dialog-title" disableTypography>
+        비밀번호 찾기
+      </DialogTitle>
+      <DialogContent className={classes.dialogContentRoot}>
+        <div className={classes.msgArea}>
+          <p>비밀번호는 이름, 가입한 아이디를 통해 랜덤하게 초기화됩니다.</p>
+          <p>초기화된 비밀번호로 로그인 후 반드시 변경해주세요.</p>
+        </div>
+        <TextField
+          autoComplete="off"
+          autoFocus
+          error={!isValidEmail}
+          helperText={isValidEmail ? HELPER_TEXT.EMAIL.DEFAULT : HELPER_TEXT.EMAIL.ERROR}
+          margin="dense"
+          name="email"
+          label="아이디"
+          type="email"
+          variant="outlined"
+          required
+          fullWidth
+          onChange={onInputChange}
+        />
+        <TextField
+          autoComplete="off"
+          error={!isValidName}
+          helperText={isValidName ? HELPER_TEXT.NAME.DEFAULT : HELPER_TEXT.NAME.ERROR}
+          margin="dense"
+          name="name"
+          label="이름"
+          type="text"
+          variant="outlined"
+          required
+          fullWidth
+          onChange={onInputChange}
+        />
+      </DialogContent>
+      <DialogActions className={classes.dialogActionRoot}>
+        <Button btnType={ButtonType.primary} onClick={onFindBtnClick} style={LOGIN_BUTTON_STYLE_PROPS} disabled={isFindDisabled} fullWidth>
+          찾기
+        </Button>
+        <div className={classes.linkTextArea}>
+          <Typography className={classes.linkText} variant="caption">
+            입력한 내용이 올바르다면 초기화된 비밀번호가 이메일로 발송됩니다.
+          </Typography>
+        </div>
+      </DialogActions>
+    </>
+  );
+};
+
+export { FindModalContent, FindModalType };
+export type { FindModalContentProps };

--- a/src/components/UI/molecules/FindModalContent/FindModalContent.tsx
+++ b/src/components/UI/molecules/FindModalContent/FindModalContent.tsx
@@ -82,7 +82,7 @@ const FindModalContent = ({ valid, isFindDisabled, onInputChange, onFindBtnClick
 
   return (
     <>
-      <DialogTitle className={classes.title} id="login-dialog-title" disableTypography>
+      <DialogTitle className={classes.title} disableTypography>
         비밀번호 찾기
       </DialogTitle>
       <DialogContent className={classes.dialogContentRoot}>

--- a/src/components/UI/molecules/HeaderLoginMenu/HeaderLoginMenu.tsx
+++ b/src/components/UI/molecules/HeaderLoginMenu/HeaderLoginMenu.tsx
@@ -13,7 +13,17 @@ const HeaderLoginMenu = (): JSX.Element => {
     modalStore.openSignUpModal();
   };
 
-  return <HeaderLoginMenuArea onLoginClick={onLoginBtnClickListener} onSignUpClick={onSignUpBtnClickListener} />;
+  const onFindBtnClickListener = () => {
+    modalStore.openFindModal();
+  };
+
+  return (
+    <HeaderLoginMenuArea
+      onLoginBtnClick={onLoginBtnClickListener}
+      onSignUpBtnClick={onSignUpBtnClickListener}
+      onFindBtnClick={onFindBtnClickListener}
+    />
+  );
 };
 
 export { HeaderLoginMenu };

--- a/src/components/UI/molecules/HeaderLoginMenu/HeaderLoginMenu.tsx
+++ b/src/components/UI/molecules/HeaderLoginMenu/HeaderLoginMenu.tsx
@@ -13,7 +13,7 @@ const HeaderLoginMenu = (): JSX.Element => {
     modalStore.openSignUpModal();
   };
 
-  const onFindBtnClickListener = () => {
+  const onFindPasswordBtnClickListener = () => {
     modalStore.openFindModal();
   };
 
@@ -21,7 +21,7 @@ const HeaderLoginMenu = (): JSX.Element => {
     <HeaderLoginMenuArea
       onLoginBtnClick={onLoginBtnClickListener}
       onSignUpBtnClick={onSignUpBtnClickListener}
-      onFindBtnClick={onFindBtnClickListener}
+      onFindPasswordBtnClick={onFindPasswordBtnClickListener}
     />
   );
 };

--- a/src/components/UI/molecules/HeaderLoginMenu/HeaderLoginMenuArea.tsx
+++ b/src/components/UI/molecules/HeaderLoginMenu/HeaderLoginMenuArea.tsx
@@ -6,7 +6,7 @@ import { makeStyles } from '@material-ui/core/styles';
 interface HeaderLoginMenuAreaProps {
   onLoginBtnClick: () => void;
   onSignUpBtnClick: () => void;
-  onFindBtnClick: () => void;
+  onFindPasswordBtnClick: () => void;
 }
 
 const BUTTON_STYLE_PROPS = { width: 192, height: 35.2, borderRadius: 4, fontSize: 19.2 };
@@ -40,7 +40,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const HeaderLoginMenuArea = ({ onLoginBtnClick, onSignUpBtnClick, onFindBtnClick }: HeaderLoginMenuAreaProps): JSX.Element => {
+const HeaderLoginMenuArea = ({ onLoginBtnClick, onSignUpBtnClick, onFindPasswordBtnClick }: HeaderLoginMenuAreaProps): JSX.Element => {
   const classes = useStyles();
 
   return (
@@ -56,7 +56,7 @@ const HeaderLoginMenuArea = ({ onLoginBtnClick, onSignUpBtnClick, onFindBtnClick
           회 원 가 입
         </Typography>
         <div className={classes.divider} />
-        <Typography className={classes.authText} variant="caption" onClick={onFindBtnClick}>
+        <Typography className={classes.authText} variant="caption" onClick={onFindPasswordBtnClick}>
           비 밀 번 호 찾 기
         </Typography>
       </div>

--- a/src/components/UI/molecules/HeaderLoginMenu/HeaderLoginMenuArea.tsx
+++ b/src/components/UI/molecules/HeaderLoginMenu/HeaderLoginMenuArea.tsx
@@ -4,8 +4,9 @@ import { Button, ButtonType } from '@/components/UI/atoms';
 import { makeStyles } from '@material-ui/core/styles';
 
 interface HeaderLoginMenuAreaProps {
-  onLoginClick: () => void;
-  onSignUpClick: () => void;
+  onLoginBtnClick: () => void;
+  onSignUpBtnClick: () => void;
+  onFindBtnClick: () => void;
 }
 
 const BUTTON_STYLE_PROPS = { width: 192, height: 35.2, borderRadius: 4, fontSize: 19.2 };
@@ -24,7 +25,7 @@ const useStyles = makeStyles((theme) => ({
   },
   divider: {
     borderLeft: `1px solid ${theme.palette.grey[500]}`,
-    margin: '0 3px',
+    margin: '0 0.3125rem',
   },
   authText: {
     color: theme.palette.grey[600],
@@ -39,7 +40,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const HeaderLoginMenuArea = ({ onLoginClick, onSignUpClick }: HeaderLoginMenuAreaProps): JSX.Element => {
+const HeaderLoginMenuArea = ({ onLoginBtnClick, onSignUpBtnClick, onFindBtnClick }: HeaderLoginMenuAreaProps): JSX.Element => {
   const classes = useStyles();
 
   return (
@@ -47,16 +48,16 @@ const HeaderLoginMenuArea = ({ onLoginClick, onSignUpClick }: HeaderLoginMenuAre
       <Typography className={classes.promotionText} variant="caption">
         한표를 더 편리하게 이용하세요
       </Typography>
-      <Button btnType={ButtonType.primary} style={BUTTON_STYLE_PROPS} onClick={onLoginClick}>
+      <Button btnType={ButtonType.primary} style={BUTTON_STYLE_PROPS} onClick={onLoginBtnClick}>
         로 그 인
       </Button>
       <div className={classes.menu}>
-        <Typography className={classes.authText} variant="caption" onClick={onSignUpClick}>
+        <Typography className={classes.authText} variant="caption" onClick={onSignUpBtnClick}>
           회 원 가 입
         </Typography>
         <div className={classes.divider} />
-        <Typography className={classes.authText} variant="caption">
-          아 이 디 / 비 밀 번 호 찾기
+        <Typography className={classes.authText} variant="caption" onClick={onFindBtnClick}>
+          비 밀 번 호 찾 기
         </Typography>
       </div>
     </div>

--- a/src/components/UI/molecules/index.ts
+++ b/src/components/UI/molecules/index.ts
@@ -32,3 +32,4 @@ export { LectureListContent } from './LectureListContent/LectureListContent';
 export { UserProfile } from './UserProfile/UserProfile';
 export { HeaderAuthSection } from './HeaderAuthSection/HeaderAuthSection';
 export { HeaderNavSection } from './HeaderNavSection/HeaderNavSection';
+export { FindModalContent, FindModalType } from './FindModalContent/FindModalContent';

--- a/src/components/UI/organisms/ModalPopup/FindModalPopup.tsx
+++ b/src/components/UI/organisms/ModalPopup/FindModalPopup.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { ModalPopupArea, FindModalContent } from '@/components/UI/molecules';
+import { useInputForm } from '@/common/hooks';
+
+interface FindModalPopupProps {
+  modalOpen: boolean;
+  onModalAreaClose: () => void;
+}
+
+interface InputState {
+  email: string;
+  name: string;
+}
+
+const INIT_INPUTS_STATE = {
+  email: '',
+  name: '',
+};
+
+const FindModalPopup = ({ modalOpen, onModalAreaClose }: FindModalPopupProps): JSX.Element => {
+  const [inputs, onInputChange, { reset, isEmpty, valids, isValid }] = useInputForm<InputState>(INIT_INPUTS_STATE, { validation: true });
+
+  const onFindBtnClickListener = () => {
+    alert('구현예정입니다.');
+  };
+
+  const onFindModalCloseListener = () => {
+    reset();
+    onModalAreaClose();
+  };
+
+  const checkFindDisabled = (): boolean => {
+    return !(!isEmpty && isValid);
+  };
+
+  return (
+    <ModalPopupArea modalOpen={modalOpen} onModalClose={onFindModalCloseListener}>
+      <FindModalContent valid={valids} isFindDisabled={checkFindDisabled()} onFindBtnClick={onFindBtnClickListener} onInputChange={onInputChange} />
+    </ModalPopupArea>
+  );
+};
+
+export { FindModalPopup };
+export type { FindModalPopupProps };

--- a/src/components/UI/organisms/ModalPopup/ModalPopup.tsx
+++ b/src/components/UI/organisms/ModalPopup/ModalPopup.tsx
@@ -1,16 +1,17 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import React from 'react';
-import { TimeTableModalType, LoginModalType, SignUpModalType, ReviewDetailModalType } from '@/components/UI/molecules';
+import { TimeTableModalType, LoginModalType, SignUpModalType, ReviewDetailModalType, FindModalType } from '@/components/UI/molecules';
 import { useStores } from '@/stores';
 import { useReactiveVar } from '@apollo/client';
 import { TimeTableModalPopup } from './TimeTableModalPopup';
 import { LoginModalPopup } from './LoginModalPopup';
 import { SignUpModalPopup } from './SignUpModalPopup';
 import { ReviewDetailModalPopup } from './ReviewDetailModalPopup';
+import { FindModalPopup } from './FindModalPopup';
 
-type ModalType = TimeTableModalType | LoginModalType | SignUpModalType | ReviewDetailModalType;
+type ModalType = TimeTableModalType | LoginModalType | SignUpModalType | ReviewDetailModalType | FindModalType;
 
-const modalTypes = { ...TimeTableModalType, ...LoginModalType, ...SignUpModalType, ...ReviewDetailModalType };
+const modalTypes = { ...TimeTableModalType, ...LoginModalType, ...SignUpModalType, ...ReviewDetailModalType, ...FindModalType };
 
 const ModalPopup = (): JSX.Element => {
   const { timeTableStore, modalStore } = useStores();
@@ -64,7 +65,10 @@ const ModalPopup = (): JSX.Element => {
           onModalAreaClose={onModalCloseListener}
         />
       );
-    return <LoginModalPopup modalOpen={nowModalState} onModalAreaClose={onModalCloseListener} />;
+
+    if (nowModalType === modalTypes.LOGIN_MODAL) return <LoginModalPopup modalOpen={nowModalState} onModalAreaClose={onModalCloseListener} />;
+
+    return <FindModalPopup modalOpen={nowModalState} onModalAreaClose={onModalCloseListener} />;
   };
 
   return <>{getModalPopup()}</>;

--- a/src/stores/ModalStore.ts
+++ b/src/stores/ModalStore.ts
@@ -64,6 +64,10 @@ class ModalStore {
   openLectureReviewDetailModal(): void {
     this.changeModalState(modalTypes.REVIEW_DETAIL_MODAL, true);
   }
+
+  openFindModal(): void {
+    this.changeModalState(modalTypes.FIND_MODAL, true);
+  }
 }
 
 export default ModalStore;


### PR DESCRIPTION
## 📑 제목

#111 비밀번호 찾기 모달 폼 제작


## 💬 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 비밀번호 찾기 모달 폼 제작
  - ModalPopup에 비밀번호 찾기 폼 type 추가
  - FindModalPopup 컴포넌트 제작 (비즈니스 로직 담당)
  - FindModalContent 컴포넌트 제작 (뷰)
- [x] 비밀번호 찾기 폼 유효성 검사 적용
  - useInputForm hook을 활용해서 적용
  - 비밀번호 찾기 폼 데이터가 빈 값이 아니고, 유효성 검사를 통과해야 찾기 버튼 활성화 되도록 구현

> 구현 결과

![ezgif com-gif-maker (47)](https://user-images.githubusercontent.com/32856129/119170417-2dbea500-ba9e-11eb-8505-02e4bf45509d.gif)

## 🚧 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 비밀번호 찾기 버튼을 누르면 서버에서 폼 데이터 인증을 거친 후, 비밀번호를 초기화, 초기화된 비밀번호를 이메일로 전송해준다는 가정하에 제작하였습니다.
- 찾기 버튼 클릭을 통한 비즈니스 로직은 아직 미구현입니다 :) 서버 API 구현 후 작업예정.